### PR TITLE
<refactor> Add additional options to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,14 +15,19 @@
 ## Types of changes
 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
-## Breaking Actions
+## Followup Actions
 <!---
     Are the changes mandatory (breaking) or optional?
     What changes must a consumer of this repository make in order to utilise it?
+    Are there other issues or steps that need to happen once this PR is merged?
+
+    Add a checklist of items or leave the default of "None"
 -->
+- [x] None
 
 ## Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
@@ -31,3 +36,4 @@
 - [ ] I have updated the documentation accordingly.
 - [ ] I have added tests to cover my changes.
 - [ ] All new and existing tests passed.
+- [ ] None of the above.


### PR DESCRIPTION
## Description
- Add a refactor option as a type of change.
- Add a none of the above item to the checklist.

## Motivation and Context
As a significant number of the PRs generated fall into this category, it feels sensible to add this as an option. The alternative is to call them features which doesn't quite feel right.

The extra checklist item is to confirm that the submitter has reviewed the checklist but not found any relevant items.

## How Has This Been Tested?
Example in https://github.com/hamlet-io/executor-bash/pull/4

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [ ] create PR for engine
- [ ] create PR for engine-core
- [ ] create PR for engine-plugin-aws
- [ ] create PR for engine-plugin-azure
- [ ] create PR for executor-cookiecutter
- [ ] create PR for executor-bash
- [ ] create PR for executor-python
- [ ] create PR for cloudinit-aws

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
