### PR TITLE
<fix> Registry scoping support for prepare/promote

### DIFF
--- a/automation/jenkins/aws/buildSetup.sh
+++ b/automation/jenkins/aws/buildSetup.sh
@@ -49,13 +49,11 @@ if [[ -z "${DEPLOYMENT_UNIT_LIST}" ]]; then
                         declare "${ATTRIBUTE^^}"="${ATTRIBUTE_VALUE}"
                     done
                     export DEPLOYMENT_UNIT_LIST="${UNITS:-${SLICES}}"
-                    export REGISTRY_SCOPE="${SCOPE,,}"
                     break
                     ;;
 
                 ref)
                     export DEPLOYMENT_UNIT_LIST=$(cat "${DU_FILE}")
-                    export REGISTRY_SCOPE=""
                     break
                     ;;
             esac
@@ -63,7 +61,6 @@ if [[ -z "${DEPLOYMENT_UNIT_LIST}" ]]; then
     done
 
     save_context_property DEPLOYMENT_UNIT_LIST
-    save_context_property REGISTRY_SCOPE
 fi
 
 # Already set image format overrides that in the repo
@@ -77,6 +74,11 @@ DEPLOYMENT_UNIT_ARRAY=(${DEPLOYMENT_UNIT_LIST})
 DEPLOYMENT_UNIT="${DEPLOYMENT_UNIT_ARRAY[0]}"
 CODE_COMMIT_ARRAY=(${CODE_COMMIT_LIST})
 CODE_COMMIT="${CODE_COMMIT_ARRAY[0]}"
+
+# Already set registry scope overrides that in the repo
+REGISTRY_SCOPE="${REGISTRY_SCOPE:-${SCOPE}}"
+export REGISTRY_SCOPE_LIST="${REGISTRY_SCOPE}"
+save_context_property REGISTRY_SCOPE_LIST
 
 # Record key parameters for downstream jobs
 save_chain_property DEPLOYMENT_UNITS "${DEPLOYMENT_UNIT_LIST}"

--- a/automation/setContext.sh
+++ b/automation/setContext.sh
@@ -490,6 +490,7 @@ function main() {
   CODE_REPO_ARRAY=()
   CODE_PROVIDER_ARRAY=()
   IMAGE_FORMATS_ARRAY=()
+  REGISTRY_SCOPE_ARRAY=()
   arrayFromList "UNITS" "${DEPLOYMENT_UNITS:-${DEPLOYMENT_UNIT:-${SLICES:-${SLICE}}}}" "${DEPLOYMENT_UNIT_SEPARATORS}"
   for CURRENT_DEPLOYMENT_UNIT in "${UNITS[@]}"; do
       [[ -z "${CURRENT_DEPLOYMENT_UNIT}" ]] && continue
@@ -497,6 +498,7 @@ function main() {
       DEPLOYMENT_UNIT_PART="${BUILD_REFERENCE_PARTS[0]}"
       TAG_PART="${BUILD_REFERENCE_PARTS[1]:-?}"
       FORMATS_PART="${BUILD_REFERENCE_PARTS[2]:-?}"
+      SCOPE_PART="${BUILD_REFERENCE_PARTS[3]:-?}"
       COMMIT_PART="?"
       if [[ ("${#DEPLOYMENT_UNIT_ARRAY[@]}" -eq 0) ||
               ("${APPLY_TO_ALL_DEPLOYMENT_UNITS}" == "true") ]]; then
@@ -511,6 +513,11 @@ function main() {
               IFS="${IMAGE_FORMAT_SEPARATORS}, " read -ra FORMATS <<< "${IMAGE_FORMATS:-${IMAGE_FORMAT}}"
               FORMATS_PART=$(IFS="${IMAGE_FORMAT_SEPARATORS}"; echo "${FORMATS[*]}")
           fi
+          if [[ -n "${REGISTRY_SCOPE}" ]]; then
+              # Permit separate variable for registry scope value - easier if
+              # all units are segment specific
+              SCOPE_PART="${REGISTRY_SCOPE}"
+          fi
       fi
 
       if [[ "${#TAG_PART}" -eq 40 ]]; then
@@ -523,6 +530,7 @@ function main() {
       CODE_COMMIT_ARRAY+=("${COMMIT_PART,,}")
       CODE_TAG_ARRAY+=("${TAG_PART}")
       IMAGE_FORMATS_ARRAY+=("${FORMATS_PART}")
+      REGISTRY_SCOPE_ARRAY+=("${SCOPE_PART}")
 
       # Determine code repo for the deployment unit - there may be none
       CODE_DEPLOYMENT_UNIT=$(tr "-" "_" <<< "${DEPLOYMENT_UNIT_PART^^}")
@@ -566,6 +574,7 @@ function main() {
   save_context_property CODE_REPO_LIST       "${CODE_REPO_ARRAY[*]}"
   save_context_property CODE_PROVIDER_LIST   "${CODE_PROVIDER_ARRAY[*]}"
   save_context_property IMAGE_FORMATS_LIST   "${IMAGE_FORMATS_ARRAY[*]}"
+  save_context_property REGISTRY_SCOPE_LIST   "${REGISTRY_SCOPE_ARRAY[*]}"
   [[ -n "${UPDATED_UNITS}" ]] && save_context_property CLEANED_DEPLOYMENT_UNITS "${UPDATED_UNITS}"
 
   ### Release management ###


### PR DESCRIPTION
## Description
Add support for registry scope on each deployment unit in any of the other deployment activities such as prepare and promote.

setContext now includes registry scope as a fourth parameter on a build reference, and an array of registry scopes is included in the context file that passes context between steps.

manageBuildReferences expects the registry scope array as with the other build reference arrays, so each build unit can have its own scope value.

## Motivation and Context
The initial support for scoped registries only supported the build/CD phase of deployment.

## How Has This Been Tested?
Tested with the site currently needing the support.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## FollowupActions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above