### PR TITLE
<refactor> Simplify output cleanup logging

### DIFF
--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -858,17 +858,25 @@ function process_template() {
   # Copy the set of result file if necessary
   if [[ "${differences_detected}" == "true" ]]; then
 
+    info "Differences detected ..."
+
+    for f in "${results_list[@]}"; do
+      info "... updating ${f} ..."
+      cp "${results_dir}/${f}" "${cf_dir}/${f}"
+    done
+
     # Cleanup output directory
     if [[ "${deployment_unit_state_subdirectories}" == "true" ]]; then
-      info "Checking output directory for unused files ..."
 
       # Remove existing files for the current level being careful to preserve stacks
       readarray -t existing_files < <(find "${cf_dir}" -mindepth 1 -maxdepth 1 -type f \
-      \( -name "${cleanup_level}-*" -and -not -name "${cleanup_level}-*-stack.json" \) )
+      \(  -name "${cleanup_level}-*" \
+          -and -not -name "${cleanup_level}-*-stack.json" \
+          -and -not -name "${cleanup_level}-*-lastchange.json" \) )
 
       for e in "${existing_files[@]}"; do
         local existing_filename="$(fileName "${e}")"
-        debug "Checking file ${existing_filename} ..."
+        debug "... checking file ${existing_filename} ..."
         # If generated, then ignore
         $(inArray "results_list" "${existing_filename}") && continue
 
@@ -878,11 +886,6 @@ function process_template() {
       done
     fi
 
-    info "Differences detected ..."
-    for f in "${results_list[@]}"; do
-      info "... updating ${f} ..."
-      cp "${results_dir}/${f}" "${cf_dir}/${f}"
-    done
   else
     info "No differences detected."
   fi


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Combine the submessages re updating and removing files.

Ensure that lastchange files are not cleaned up - they are treated the same as stacks.
## Motivation and Context
Cleaning up is only done when differences are detected so combine all the cleanup messages under a single heading.

Lastchange files are related to stack processing not template processing so treat the same as stacks i.e. don't delete.

## How Has This Been Tested?
Locally ran template creation and confirmed that 
- the output messages were as expected
- the lastchange.json file was not removed.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Breaking Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above
