### PR TITLE
updated commands from deprecated to recommended

### DIFF
--- a/cli/manageDeployment.sh
+++ b/cli/manageDeployment.sh
@@ -123,9 +123,9 @@ function wait_for_deployment_execution() {
     case ${DEPLOYMENT_OPERATION} in
       update | create)
         if [[ "${DEPLOYMENT_SCOPE}" == "resourceGroup" ]]; then
-          DEPLOYMENT=$(az group deployment show --resource-group "${RESOURCE_GROUP}" --name "${DEPLOYMENT_NAME}")
+          DEPLOYMENT=$(az deployment group show --resource-group "${RESOURCE_GROUP}" --name "${DEPLOYMENT_NAME}")
         else
-          DEPLOYMENT=$(az deployment show --name "${DEPLOYMENT_NAME}")
+          DEPLOYMENT=$(az deployment sub show --name "${DEPLOYMENT_NAME}")
         fi
       ;;
       delete)
@@ -224,7 +224,7 @@ function process_deployment() {
           fi
 
           info "Validating template..."
-          az group deployment validate ${group_deployment_args[@]/#/--} > /dev/null || return $?
+          az deployment group validate ${group_deployment_args[@]/#/--} > /dev/null || return $?
           info "Template is valid."
 
           # add remaining deployment options
@@ -236,7 +236,7 @@ function process_deployment() {
 
           # Execute the deployment to the resource group
           info "Starting deployment of ${DEPLOYMENT_NAME} to the Resource Group ${RESOURCE_GROUP}."
-          az group deployment create ${group_deployment_args[@]/#/--} > /dev/null || return $?
+          az deployment group create ${group_deployment_args[@]/#/--} > /dev/null || return $?
 
         elif [[ "${DEPLOYMENT_SCOPE}" == "subscription" ]]; then
 
@@ -254,7 +254,7 @@ function process_deployment() {
 
           # validate subscription level deployment
           info "Validating template..."
-          az deployment validate ${subscription_deployment_args[@]/#/--} > /dev/null || return $?
+          az deployment sub validate ${subscription_deployment_args[@]/#/--} > /dev/null || return $?
           info "Template is valid."
 
           subscription_deployment_args=(
@@ -265,7 +265,7 @@ function process_deployment() {
 
           # Execute the deployment to the subscription
           info "Starting deployment of ${DEPLOYMENT_NAME} to the subscription."
-          az deployment create ${subscription_deployment_args[@]/#/--} > /dev/null || return $?
+          az deployment sub create ${subscription_deployment_args[@]/#/--} > /dev/null || return $?
 
         fi
 
@@ -277,7 +277,7 @@ function process_deployment() {
 
           # Delete the resource group
           info "Deleting the ${RESOURCE_GROUP} resource group"
-          az group delete --resource-group "${RESOURCE_GROUP}" --no-wait --yes
+          az deployment group delete --resource-group "${RESOURCE_GROUP}" --no-wait --yes
 
           wait_for_deployment_execution
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Addresses and Closes #12 - updating Az CLI commands from the deprecated ones to the latest ones.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Deprecation warnings during all deployments warning us that eventually these commands would stop working.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Updated locally and performed a deployment - no warnings.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
