### PR TITLE
<refactor> remove progress log entries on s3 registry

### DIFF
--- a/automation/jenkins/aws/manageS3Registry.sh
+++ b/automation/jenkins/aws/manageS3Registry.sh
@@ -239,7 +239,7 @@ function copyToRegistry() {
         [[ "$RESULT" -ne 0 ]] &&
             fatal "Can't access ${FILE_TO_COPY}" && RESULT=1 && exit
 
-        aws --region "${REGISTRY_PROVIDER_REGION}" s3 cp --recursive "${FILE_TO_COPY}" "${FULL_REGISTRY_IMAGE_PATH}/"
+        aws --region "${REGISTRY_PROVIDER_REGION}" s3 cp --no-progress --recursive "${FILE_TO_COPY}" "${FULL_REGISTRY_IMAGE_PATH}/"
 
     else
 
@@ -257,14 +257,14 @@ function copyToRegistry() {
                     fatal "Unable to unzip ${FILE_TO_COPY}" && RESULT=1 && exit
         fi
 
-        aws --region "${REGISTRY_PROVIDER_REGION}" s3 cp --recursive "${FILES_TEMP_DIR}/" "${FULL_REGISTRY_IMAGE_PATH}/"
+        aws --region "${REGISTRY_PROVIDER_REGION}" s3 cp --no-progress --recursive "${FILES_TEMP_DIR}/" "${FULL_REGISTRY_IMAGE_PATH}/"
         RESULT=$?
         [[ $RESULT -ne 0 ]] &&
             fatal "Unable to save ${BASE_REGISTRY_FILENAME} in the local registry" && RESULT=1 && exit
 
     fi
 
-    aws --region "${REGISTRY_PROVIDER_REGION}" s3 cp "${TAG_FILE}" "${FULL_TAGGED_REGISTRY_IMAGE}"
+    aws --region "${REGISTRY_PROVIDER_REGION}" s3 cp --no-progress "${TAG_FILE}" "${FULL_TAGGED_REGISTRY_IMAGE}"
     RESULT=$?
     [[ $RESULT -ne 0 ]] &&
         fatal "Unable to tag ${BASE_REGISTRY_FILENAME} as latest" && RESULT=1 && exit
@@ -410,7 +410,7 @@ case ${REGISTRY_OPERATION} in
             fatal "Can't find ${REGISTRY_IMAGE} in ${REGISTRY_PROVIDER_DNS}" && RESULT=1 && exit
         else
             # Copy to S3
-            aws --region "${REGISTRY_PROVIDER_REGION}" s3 cp "${TAG_FILE}" "${FULL_REMOTE_TAGGED_REGISTRY_IMAGE}"
+            aws --region "${REGISTRY_PROVIDER_REGION}" s3 cp --no-progress "${TAG_FILE}" "${FULL_REMOTE_TAGGED_REGISTRY_IMAGE}"
             RESULT=$?
             [[ "${RESULT}" -ne 0 ]] &&
                 fatal "Couldn't tag image ${FULL_REGISTRY_IMAGE} with tag ${REMOTE_REGISTRY_TAG}" && RESULT=1 && exit
@@ -437,7 +437,7 @@ case ${REGISTRY_OPERATION} in
             fatal "Can't find ${REMOTE_REGISTRY_IMAGE} in ${REMOTE_REGISTRY_PROVIDER_DNS}" && RESULT=1 && exit
         else
             # Copy image
-            aws --region "${REGISTRY_PROVIDER_REGION}" s3 cp "${FULL_REMOTE_REGISTRY_IMAGE}" "${IMAGE_FILE}"
+            aws --region "${REGISTRY_PROVIDER_REGION}" s3 cp --no-progress "${FULL_REMOTE_REGISTRY_IMAGE}" "${IMAGE_FILE}"
             RESULT=$?
             [[ "$RESULT" -ne 0 ]] &&
                 fatal "Can't copy remote image ${FULL_REMOTE_REGISTRY_IMAGE}" && RESULT=1 && exit


### PR DESCRIPTION
## Description
Removes progress logging from s3 registry management scripts

## Motivation and Context
When copying large registries the log messages overwhelm the rest of the job logs. Removing the progress log entries still maintains the list of files copied in the log, it doesn't include the percentage progress.

## How Has This Been Tested?
Tested in releases of active deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
