### PR TITLE
fix: Fragment processing

### DIFF
--- a/execution/setContext.sh
+++ b/execution/setContext.sh
@@ -52,29 +52,6 @@ fi
 export CACHE_DIR="${GENERATION_DATA_DIR}/cache"
 mkdir -p "${CACHE_DIR}"
 
-# Generate the list of files constituting the composites based on the contents
-# of the account
-# The blueprint is handled specially as its logic is different to the others
-TEMPLATE_COMPOSITES=("account" "fragment")
-
-for composite in "${TEMPLATE_COMPOSITES[@]}"; do
-    # Define the composite
-    declare -gx COMPOSITE_${composite^^}="${CACHE_DIR}/composite_${composite}.ftl"
-
-    if [[ (("${GENERATION_USE_CACHE}" != "true")  &&
-            ("${GENERATION_USE_FRAGMENTS_CACHE}" != "true")) ||
-          (! -f "${CACHE_DIR}/composite_account.ftl") ]]; then
-        # define the array holding the list of composite fragment filenames
-        declare -ga "${composite}_array"
-
-        # Legacy start fragments
-        for fragment in "${GENERATION_ENGINE_DIR}"/legacy/${composite}/start*.ftl; do
-            $(inArray "${composite}_array" $(fileName "${fragment}")) && continue
-            addToArray "${composite}_array" "${fragment}"
-        done
-    fi
-done
-
 # Check if the current directory gives any clue to the context
 # Accommodate both pre cmdb v2.0.0 where segment/environment in the config tree
 # and post v2.0.0 where they are in the infrastructure tree


### PR DESCRIPTION
## Description
With the splitting of fragment assembly across setContext.sh and createTemplate.sh, `TEMPLATE_COMPOSITES` needs to be exported so that it is available to a later invocation of createTemplate.sh.

## Motivation and Context
Needed to correct execution logic for expo builds.

## How Has This Been Tested?
Customer build

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
