### PR TITLE
fix(db): ensure db password resets are performed when required

### DIFF
--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -1894,9 +1894,9 @@ function set_rds_master_password() {
 
   info "Resetting master password for RDS instance ${db_identifier}"
   if [[ "${db_type}" == "cluster" ]]; then
-    aws --region "${region}" rds modify-db-cluster --db-cluster-identifier "${db_identifier}" --master-user-password "${password}" 1> /dev/null
+    aws --region "${region}" rds modify-db-cluster --db-cluster-identifier "${db_identifier}" --master-user-password "${password}" --apply-immediately 1> /dev/null
   else
-    aws --region "${region}" rds modify-db-instance --db-instance-identifier ${db_identifier} --master-user-password "${password}" 1> /dev/null
+    aws --region "${region}" rds modify-db-instance --db-instance-identifier ${db_identifier} --master-user-password "${password}" --apply-immediately 1> /dev/null
   fi
 }
 


### PR DESCRIPTION
## Description
Ensures passwords are reset during the deployment rather than being scheduled for the next maintenance window in RDS updates

## Motivation and Context
It appear that Aurora clusters in AWS RDS environments by default schedule password resets for the next maintenance windows rather than applying them immediately. This means that with our current password  configuration process on each deployment the password will be reset to a dummy value and wont be set to the correct value until the next window. 


## How Has This Been Tested?
Tested on live deployment

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
