### PR TITLE
fix: Fragment handling when composite cacheing enabled

### DIFF
--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -129,9 +129,6 @@ function options() {
         TEMPLATE_COMPOSITES=("account" "fragment")
         for composite in "${TEMPLATE_COMPOSITES[@]}"; do
 
-          # Define the composite
-          declare -gx COMPOSITE_${composite^^}="${CACHE_DIR}/composite_${composite}.ftl"
-
           # define the array holding the list of composite fragment filenames
           declare -ga "${composite}_array"
 
@@ -208,7 +205,7 @@ function options() {
 
   fi
 
-  # Specific intput control for mock input
+  # Specific input control for mock input
   if [[ "${GENERATION_INPUT_SOURCE}" == "mock" ]]; then
 
     if [[ -z "${OUTPUT_DIR}" ]]; then
@@ -460,8 +457,8 @@ function process_template_pass() {
   # Removal of drive letter (/?/) is specifically for MINGW
   # It shouldn't affect other platforms as it won't be matched
   for composite in "${template_composites[@]}"; do
-    composite_var="COMPOSITE_${composite^^}"
-    args+=("-r" "${composite,,}List=${!composite_var#/?/}")
+    composite_var="${CACHE_DIR}/composite_${composite,,}.ftl"
+    args+=("-r" "${composite,,}List=${composite_var#/?/}")
   done
 
   args+=("-g" "${GENERATION_DATA_DIR}")


### PR DESCRIPTION

## Description
Composite lists were not being included when cacheing was enabled.

Simplify the logic by removing a redundant environment variable used to pass the path to each composite file.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Cacheing wasn't usable as builds failed without the composite fragment.

## How Has This Been Tested?
Local deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
