### PR TITLE
feat: Re-encrypt and list cmk crypto operations

### DIFF
--- a/cli/manageCrypto.sh
+++ b/cli/manageCrypto.sh
@@ -18,7 +18,7 @@ function usage() {
 
 Manage cryptographic operations using KMS
 
-Usage: $(basename $0) -e -d -n -b -u -v -q
+Usage: $(basename $0) -e -d -n -b -u -v -q -l -r
                         -f CRYPTO_FILE
                         -p JSON_PATH
                         -t CRYPTO_TEXT
@@ -35,9 +35,11 @@ where
 (o) -f CRYPTO_FILE  specifies a file which contains the plaintext or ciphertext to be processed
     -h              shows this text
 (o) -k KEYID        for the master key to be used
+(o) -l              list cmk operation
 (o) -n              no alteration to CRYPTO_TEXT (pass through as is)
 (o) -p JSON_PATH    is the path to the attribute within CRYPTO_FILE to be processed
 (o) -q              don't display result (quiet)
+(o) -r              re-encrypt operation
 (o) -t CRYPTO_TEXT  is the plaintext or ciphertext to be processed
     -u              update the attribute at JSON_PATH (if provided), or replace CRYPTO_FILE with operation result
     -v              result is base64 decoded (visible)
@@ -84,7 +86,7 @@ EOF
 
 function options() {
     # Parse options
-    while getopts ":a:bdef:hk:np:qt:uvx:" opt; do
+    while getopts ":a:bdef:hk:lnp:qrt:uvx:" opt; do
         case $opt in
             a)
                 ALIAS="${OPTARG}"
@@ -107,6 +109,9 @@ function options() {
             k)
                 KEYID="${OPTARG}"
                 ;;
+            l)
+                CRYPTO_OPERATION="listcmk"
+                ;;
             n)
                 CRYPTO_OPERATION="noop"
                 ;;
@@ -115,6 +120,9 @@ function options() {
                 ;;
             q)
                 CRYPTO_QUIET="true"
+                ;;
+            r)
+                CRYPTO_OPERATION="reencrypt"
                 ;;
             t)
                 CRYPTO_TEXT="${OPTARG}"
@@ -129,10 +137,10 @@ function options() {
                 PREFIX="${OPTARG}"
                 ;;
             \?)
-                fatalOption
+                fatalOption && return 1
                 ;;
             :)
-                fatalOptionArgument
+                fatalOptionArgument && return 1
                 ;;
         esac
     done
@@ -162,40 +170,44 @@ function main() {
     fi
 
     # If not provided find the key using the cmdb
-    if [[ -z "${KEYID}" && "${CRYPTO_OPERATION}" == "encrypt" ]]; then
+    if [[ -z "${KEYID}" ]]; then
+        case ${CRYPTO_OPERATION} in
+            encrypt|reencrypt|listcmk)
 
-        info "Finding Segment CMK..."
-        ${GENERATION_DIR}/createBuildblueprint.sh -u baseline -o "${tmp_dir}/" >/dev/null || return $?
+                info "Finding Segment CMK..."
+                ${GENERATION_DIR}/createBuildblueprint.sh -u baseline -o "${tmp_dir}/" >/dev/null || return $?
 
-        BUILD_BLUEPRINT="${tmp_dir}/build_blueprint-baseline-config.json"
+                BUILD_BLUEPRINT="${tmp_dir}/build_blueprint-baseline-config.json"
 
-        case "${LOCATION}" in
-            "segment")
+                case "${LOCATION}" in
+                    "segment")
 
-                arrayFromList "KEY_IDS" "$(jq -r '.Occurrence.Occurrences[] | select( .Core.Type == "baselinekey" and .Configuration.Solution.Engine == "cmk" ) | .State.Attributes.ARN' < ${BUILD_BLUEPRINT})"
+                        arrayFromList "KEY_IDS" "$(jq -r '.Occurrence.Occurrences[] | select( .Core.Type == "baselinekey" and .Configuration.Solution.Engine == "cmk" ) | .State.Attributes.ARN' < ${BUILD_BLUEPRINT})"
 
-                if [[ "$(arraySize "KEY_IDS" )" > 1 ]]; then
-                    fatal "Multiple keys found - please run again using the -k parameter"
-                    fatal "Keys Found: $(listFromArray "KEYID" )"
+                        if [[ "$(arraySize "KEY_IDS" )" > 1 ]]; then
+                            fatal "Multiple keys found - please run again using the -k parameter"
+                            fatal "Keys Found: $(listFromArray "KEYID" )"
+                            return 255
+                        else
+                            KEYID="${KEY_IDS[0]}"
+                        fi
+                        ;;
+
+                    "account"|"root"|"integrator")
+
+                        KEYID="$(jq -r '.Occurrence.Occurrences[] | select( .Core.Type == "baselinekey" and .Configuration.Solution.Engine == "cmk-account" ) | .State.Attributes.ARN' < ${BUILD_BLUEPRINT})"
+
+                        ;;
+                esac
+
+                if [[ -z "${KEYID}" ]]; then
+                    fatal "No key material available"
                     return 255
-                else
-                    KEYID="${KEY_IDS[0]}"
                 fi
-                ;;
 
-            "account"|"root"|"integrator")
-
-                KEYID="$(jq -r '.Occurrence.Occurrences[] | select( .Core.Type == "baselinekey" and .Configuration.Solution.Engine == "cmk-account" ) | .State.Attributes.ARN' < ${BUILD_BLUEPRINT})"
-
+                debug "Key to be used is ${KEYID}"
                 ;;
         esac
-
-        if [[ -z "${KEYID}" ]]; then
-            fatal "No key material available"
-            return 255
-        fi
-
-        debug "Key to be used is ${KEYID}"
     fi
 
     # Location base file search
@@ -298,6 +310,26 @@ function main() {
             CRYPTO_TEXT=$(cd "${tmp_dir}"; aws --region ${REGION} --output text kms decrypt \
                 --query Plaintext \
                 --ciphertext-blob "fileb://ciphertext.bin")
+            ;;
+        reencrypt)
+            CRYPTO_TEXT=$(cd "${tmp_dir}"; aws --region ${REGION} --output text kms re-encrypt \
+                --query CiphertextBlob \
+                --destination-key-id "${KEYID}" \
+                --ciphertext-blob "fileb://ciphertext.bin")
+            ;;
+        listcmk)
+            CMK_ARN=$(cd "${tmp_dir}"; aws --region ${REGION} --output text kms re-encrypt \
+                --query SourceKeyId \
+                --destination-key-id "${KEYID}" \
+                --ciphertext-blob "fileb://ciphertext.bin")
+            CMK_ALIAS=$(cd "${tmp_dir}"; aws --region ${REGION} --output text kms list-aliases \
+                --key-id "${CMK_ARN}" \
+                --query "Aliases[0].AliasName")
+            # List only - force settings accordingly
+            CRYPTO_TEXT="ALIAS=${CMK_ALIAS#alias/} ARN=${CMK_ARN}"
+            CRYPTO_VISIBLE=false
+            CRYPTO_UPDATE=false
+            #
             ;;
         noop)
             # Don't touch CRYPTO_TEXT so either existing value will be displayed, or

--- a/cli/manageFileCrypto.sh
+++ b/cli/manageFileCrypto.sh
@@ -11,7 +11,7 @@ function usage() {
 
 Manage crypto for files
 
-Usage: $(basename $0) -f CRYPTO_FILE -e -d -u -a KEYALIAS -k KEYID
+Usage: $(basename $0) -f CRYPTO_FILE -e -d -l -r -u -a KEYALIAS -k KEYID
 
 where
 
@@ -21,6 +21,8 @@ where
 (o) -f CRYPTO_FILE  is the path to the file managed
     -h              shows this text
 (o) -k KEYID        for the master key to be used
+(o) -l              if cmk should be listed
+(o) -r              if file should be re-encrypted
 (o) -u              if file should be updated
 
 (m) mandatory, (o) optional, (d) deprecated
@@ -36,7 +38,7 @@ EOF
 }
 
 # Parse options
-while getopts ":a:def:hk:u" opt; do
+while getopts ":a:def:hk:lru" opt; do
     case $opt in
         a)
             export ALIAS="${OPTARG}"
@@ -56,14 +58,20 @@ while getopts ":a:def:hk:u" opt; do
         k)
             export KEYID="${OPTARG}"
             ;;
+        l)
+            export CRYPTO_OPERATION="listcmk"
+            ;;
+        r)
+            export CRYPTO_OPERATION="reencrypt"
+            ;;
         u)
             export CRYPTO_UPDATE="true"
             ;;
         \?)
-            fatalOption
+            fatalOption && exit 1
             ;;
         :)
-            fatalOptionArgument
+            fatalOptionArgument && exit 1
             ;;
     esac
 done
@@ -75,6 +83,12 @@ case $CRYPTO_OPERATION in
         ;;
     decrypt)
         ${GENERATION_DIR}/manageCrypto.sh -b -d -v
+        ;;
+    listcmk)
+        ${GENERATION_DIR}/manageCrypto.sh -b -l
+        ;;
+    reencrypt)
+        ${GENERATION_DIR}/manageCrypto.sh -b -r
         ;;
     *)
         ${GENERATION_DIR}/manageCrypto.sh -n


### PR DESCRIPTION
## Description
Add the ability to re-encrypt existing ciphertext. This makes creating new segments much easier where files or attributes need to have the same plaintext values. Instead of having to obtain the plaintext, existing ciphertext can be copied and then re-encrypted.

The re-encrypt command also provides the original key id as an output, so this has been used to provide the ability to list the cmk used to encrypt any ciphertext. The resulting value is then used to query what alias the key has.

## Motivation and Context
Simplify the management of encrypted configuration

## How Has This Been Tested?
Local cmdb updates

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
