### PR TITLE
feat(externalnetwork): vpn attachment lookup

### DIFF
--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -1617,6 +1617,20 @@ function update_ssm_document() {
   return $?
 }
 
+# -- Transit Gateway --
+
+function get_transitgateway_vpn_attachment() {
+  local region="$1"; shift
+  local cfnStackName="$1"; shift
+  local vpnConnectionId="$1"; shift
+
+  vpnConnection="$(get_cloudformation_stack_output "${region}" "${cfnStackName}" "${vpnConnectionId}" "ref" || return $?)"
+  transitGatewayAttachment="$( aws --region "${region}" ec2 describe-transit-gateway-attachments --filters "Name=resource-id,Values=${vpnConnection}" --query 'TransitGatewayAttachments[*].TransitGatewayAttachmentId' --output text || return $? )"
+
+  echo "${transitGatewayAttachment}"
+  return 0
+}
+
 # -- OAI --
 
 function update_oai_credentials() {


### PR DESCRIPTION
## Description
Adds a lookup for the TransitGateway attachment when using a VPN connection. 
Required for: https://github.com/hamlet-io/engine-plugin-aws/pull/48 

## Motivation and Context
The VPNConnection Cloudformation resource is used to attach to a TransitGateway, as a result of this the Transit Gateway attachment Id isn't available from Cloudformation. The attachment Id is required for routing configuration and propogation config 

This is covered as a request to the CFN team in https://github.com/aws-cloudformation/aws-cloudformation-coverage-roadmap/issues/308 

## How Has This Been Tested?
Tested locally 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
