### PR TITLE
feat(ec2): volume encryption

### DIFF
--- a/execution/contextTree.sh
+++ b/execution/contextTree.sh
@@ -726,7 +726,7 @@ function isValidUnit() {
   # Check unit if required
   if [[ "${unit_required[${level}]}" == "true" ]]; then
     # Default deployment units for each level
-    declare -ga ACCOUNT_UNITS_ARRAY=("iam" "lg" "audit" "s3" "cert" "roles" "apigateway" "waf" "sms" "console")
+    declare -ga ACCOUNT_UNITS_ARRAY=("cmk" "iam" "lg" "audit" "s3" "cert" "roles" "apigateway" "waf" "sms" "console" "volumeencrypt")
     declare -ga PRODUCT_UNITS_ARRAY=("s3" "sns" "cert" "cmk")
     declare -ga BUILDBLUEPRINT_UNITS_ARRAY=(${unit})
     declare -ga APPLICATION_UNITS_ARRAY=(${unit})


### PR DESCRIPTION
## Description
Adds support for Ec2 volume encryption by default
- A utility to support controlling the state of the encryption 
- Additional account level units to support the required services

## Motivation and Context
AWS have introduced a regional level setting which enables encryption on EBS volumes by default. This saves having to enable it on a disk by disk basis. 

## How Has This Been Tested?
Tested on local deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
