### PR TITLE
feat(console): replace ssm document creation with cleanup

### DIFF
--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -1625,7 +1625,6 @@ function cleanup_ssm_document() {
 
   if [[ -n "${listDocument}" ]]; then
 
-    # if document doesn't exist create it
     info "Removing Document ${name}"
     aws --region "${region}" ssm delete-document --name "${name}" || return $?
 

--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -1617,22 +1617,19 @@ function delete_ssh_credentials() {
 
 # -- SSM --
 
-function update_ssm_document() {
+function cleanup_ssm_document() {
   local region="$1"; shift
   local name="$1"; shift
-  local version="$1"; shift
-  local contentfile="$1"; shift
 
-  local currentHash="$(aws ssm describe-document --region "${region}" --name "${name}" --document-version "${version}" --query 'Document.Hash' --output text || return $?)"
-  local newHash="$(shasum -a 256 ${contentfile} | cut -d " " -f 1 || return $?)"
+  listDocument="$(aws --region "${region}" ssm list-documents  --filters Key=Name,Values="${name}" --query 'DocumentIdentifiers[*].Name' --output text )"
 
-  if [[ "${currentHash}" != "${newHash}" ]]; then
-    aws ssm update-document --region "${region}" --name "${name}" --document-version "${version}" --content "file://${contentfile}" || return $?
-  else
-    info "No changes required"
+  if [[ -n "${listDocument}" ]]; then
+
+    # if document doesn't exist create it
+    info "Removing Document ${name}"
+    aws --region "${region}" ssm delete-document --name "${name}" || return $?
+
   fi
-
-  return $?
 }
 
 # -- Transit Gateway --


### PR DESCRIPTION
## Description
Companion PR to hamlet-io/engine#1343 
With the move to use Cloudformation for creating the SSM Session manager document we no longer need to create documents via the Cli. 

However we do need to be able to clean up the documents created outside of CFN, so instead we need a cleanup function

## Motivation and Context
To support the changes in hamlet-io/engine#1343 

## How Has This Been Tested?
Tested on local deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
