### PR TITLE
feat(azure): Support for credentials and consistent stack naming

### DIFF
--- a/automation/jenkins/aws/setCredentials.sh
+++ b/automation/jenkins/aws/setCredentials.sh
@@ -6,78 +6,152 @@
 #
 # $1 = account to be accessed
 
-AWS_CRED_ACCOUNT="${1^^}"
+CRED_ACCOUNT="${1^^}"
 
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 
-# Clear any previous results
-unset AWS_CRED_AWS_ACCESS_KEY_ID_VAR
-unset AWS_CRED_AWS_SECRET_ACCESS_KEY_VAR
-unset AWS_CRED_TEMP_AWS_ACCESS_KEY_ID
-unset AWS_CRED_TEMP_AWS_SECRET_ACCESS_KEY
-unset AWS_CRED_TEMP_AWS_SESSION_TOKEN
+CRED_ACCOUNT_CLOUD_PROVIDER_VAR="${CRED_ACCOUNT}_CLOUD_PROVIDER"
 
-# Determine default maximum validity period - align to role default
-AUTOMATION_ROLE_VALIDITY="${AUTOMATION_ROLE_VALIDITY:-3600}"
-
-# First check for account specific credentials
-AWS_CRED_OVERRIDE_AWS_ACCESS_KEY_ID_VAR="${AWS_CRED_ACCOUNT}_AWS_ACCESS_KEY_ID"
-AWS_CRED_OVERRIDE_AWS_SECRET_ACCESS_KEY_VAR="${AWS_CRED_ACCOUNT}_AWS_SECRET_ACCESS_KEY"
-if [[ (-n "${!AWS_CRED_OVERRIDE_AWS_ACCESS_KEY_ID_VAR}") && (-n "${!AWS_CRED_OVERRIDE_AWS_SECRET_ACCESS_KEY_VAR}") ]]; then
-    AWS_CRED_AWS_ACCESS_KEY_ID_VAR="${AWS_CRED_OVERRIDE_AWS_ACCESS_KEY_ID_VAR}"
-    AWS_CRED_AWS_SECRET_ACCESS_KEY_VAR="${AWS_CRED_OVERRIDE_AWS_SECRET_ACCESS_KEY_VAR})"
+if [[ -z "${CRED_ACCOUNT_PROVIDER_VAR}" ]]; then
+    if [[ -n "${AZID}" ]]; then
+        CLOUD_PROVIDER="azure"
+    else
+        CLOUD_PROVIDER="aws"
+    fi
 else
-    # Check for a global automation user/role
-    AWS_CRED_AWS_ACCOUNT_ID_VAR="${AWS_CRED_ACCOUNT}_AWS_ACCOUNT_ID"
-    AWS_CRED_AUTOMATION_USER_VAR="${AWS_CRED_ACCOUNT}_AUTOMATION_USER"
-    if [[ -z "${!AWS_CRED_AUTOMATION_USER_VAR}" ]]; then AWS_CRED_AUTOMATION_USER_VAR="AWS_AUTOMATION_USER"; fi
-    AWS_CRED_AUTOMATION_ROLE_VAR="${AWS_CRED_ACCOUNT}_AUTOMATION_ROLE"
-    if [[ -z "${!AWS_CRED_AUTOMATION_ROLE_VAR}" ]]; then AWS_CRED_AUTOMATION_ROLE_VAR="AWS_AUTOMATION_ROLE"; fi
-    AWS_CRED_AUTOMATION_ROLE="${!AWS_CRED_AUTOMATION_ROLE_VAR:-codeontap-automation}"
+    CLOUD_PROVIDER="${CRED_ACCOUNT_CLOUD_PROVIDER_VAR}"
+fi
 
-    if [[ (-n ${!AWS_CRED_AWS_ACCOUNT_ID_VAR}) && (-n ${!AWS_CRED_AUTOMATION_USER_VAR}) ]]; then
-        # Assume automation role either
-        # - using the role we are current running under, or
-        # - using credentails associated with the automation user
-        # Note that the value for the user is just a way to obtain the access credentials
-        # and doesn't have to be the same as the IAM user associated with the credentials
-        if [[ "${!AWS_CRED_AUTOMATION_USER_VAR^^}" == "ROLE" ]]; then
-            # Clear any use of previously obtained credentials
-            unset AWS_ACCESS_KEY_ID
-            unset AWS_SECRET_ACCESS_KEY
+case "${CLOUD_PROVIDER}" in
+    aws)
+
+        # Clear any previous results
+        unset AWS_CRED_AWS_ACCESS_KEY_ID_VAR
+        unset AWS_CRED_AWS_SECRET_ACCESS_KEY_VAR
+        unset AWS_CRED_TEMP_AWS_ACCESS_KEY_ID
+        unset AWS_CRED_TEMP_AWS_SECRET_ACCESS_KEY
+        unset AWS_CRED_TEMP_AWS_SESSION_TOKEN
+
+        # Determine default maximum validity period - align to role default
+        AUTOMATION_ROLE_VALIDITY="${AUTOMATION_ROLE_VALIDITY:-3600}"
+
+        # First check for account specific credentials
+        AWS_CRED_OVERRIDE_AWS_ACCESS_KEY_ID_VAR="${CRED_ACCOUNT}_AWS_ACCESS_KEY_ID"
+        AWS_CRED_OVERRIDE_AWS_SECRET_ACCESS_KEY_VAR="${CRED_ACCOUNT}_AWS_SECRET_ACCESS_KEY"
+        if [[ (-n "${!AWS_CRED_OVERRIDE_AWS_ACCESS_KEY_ID_VAR}") && (-n "${!AWS_CRED_OVERRIDE_AWS_SECRET_ACCESS_KEY_VAR}") ]]; then
+            AWS_CRED_AWS_ACCESS_KEY_ID_VAR="${AWS_CRED_OVERRIDE_AWS_ACCESS_KEY_ID_VAR}"
+            AWS_CRED_AWS_SECRET_ACCESS_KEY_VAR="${AWS_CRED_OVERRIDE_AWS_SECRET_ACCESS_KEY_VAR})"
         else
-            # Not using current role so determine the credentials
-            AWS_CRED_AWS_ACCESS_KEY_ID_VAR="${!AWS_CRED_AUTOMATION_USER_VAR^^}_AWS_ACCESS_KEY_ID"
-            AWS_CRED_AWS_SECRET_ACCESS_KEY_VAR="${!AWS_CRED_AUTOMATION_USER_VAR^^}_AWS_SECRET_ACCESS_KEY"
-            AWS_CRED_AWS_ACCESS_KEY_ID="${!AWS_CRED_AWS_ACCESS_KEY_ID_VAR}"
-            AWS_CRED_AWS_SECRET_ACCESS_KEY="${!AWS_CRED_AWS_SECRET_ACCESS_KEY_VAR}"
+            # Check for a global automation user/role
+            AWS_CRED_AWS_ACCOUNT_ID_VAR="${CRED_ACCOUNT}_AWS_ACCOUNT_ID"
+            AWS_CRED_AUTOMATION_USER_VAR="${CRED_ACCOUNT}_AUTOMATION_USER"
+            if [[ -z "${!AWS_CRED_AUTOMATION_USER_VAR}" ]]; then AWS_CRED_AUTOMATION_USER_VAR="AWS_AUTOMATION_USER"; fi
+            AWS_CRED_AUTOMATION_ROLE_VAR="${CRED_ACCOUNT}_AUTOMATION_ROLE"
+            if [[ -z "${!AWS_CRED_AUTOMATION_ROLE_VAR}" ]]; then AWS_CRED_AUTOMATION_ROLE_VAR="AWS_AUTOMATION_ROLE"; fi
+            AWS_CRED_AUTOMATION_ROLE="${!AWS_CRED_AUTOMATION_ROLE_VAR:-codeontap-automation}"
 
-            if [[ (-n ${AWS_CRED_AWS_ACCESS_KEY_ID}) && (-n ${AWS_CRED_AWS_SECRET_ACCESS_KEY}) ]]; then
-                export AWS_ACCESS_KEY_ID="${AWS_CRED_AWS_ACCESS_KEY_ID}"
-                export AWS_SECRET_ACCESS_KEY="${AWS_CRED_AWS_SECRET_ACCESS_KEY}"
+            if [[ (-n ${!AWS_CRED_AWS_ACCOUNT_ID_VAR}) && (-n ${!AWS_CRED_AUTOMATION_USER_VAR}) ]]; then
+                # Assume automation role either
+                # - using the role we are current running under, or
+                # - using credentails associated with the automation user
+                # Note that the value for the user is just a way to obtain the access credentials
+                # and doesn't have to be the same as the IAM user associated with the credentials
+                if [[ "${!AWS_CRED_AUTOMATION_USER_VAR^^}" == "ROLE" ]]; then
+                    # Clear any use of previously obtained credentials
+                    unset AWS_ACCESS_KEY_ID
+                    unset AWS_SECRET_ACCESS_KEY
+                else
+                    # Not using current role so determine the credentials
+                    AWS_CRED_AWS_ACCESS_KEY_ID_VAR="${!AWS_CRED_AUTOMATION_USER_VAR^^}_AWS_ACCESS_KEY_ID"
+                    AWS_CRED_AWS_SECRET_ACCESS_KEY_VAR="${!AWS_CRED_AUTOMATION_USER_VAR^^}_AWS_SECRET_ACCESS_KEY"
+                    AWS_CRED_AWS_ACCESS_KEY_ID="${!AWS_CRED_AWS_ACCESS_KEY_ID_VAR}"
+                    AWS_CRED_AWS_SECRET_ACCESS_KEY="${!AWS_CRED_AWS_SECRET_ACCESS_KEY_VAR}"
+
+                    if [[ (-n ${AWS_CRED_AWS_ACCESS_KEY_ID}) && (-n ${AWS_CRED_AWS_SECRET_ACCESS_KEY}) ]]; then
+                        export AWS_ACCESS_KEY_ID="${AWS_CRED_AWS_ACCESS_KEY_ID}"
+                        export AWS_SECRET_ACCESS_KEY="${AWS_CRED_AWS_SECRET_ACCESS_KEY}"
+                    fi
+                fi
+
+                if [[ ("${!AWS_CRED_AUTOMATION_USER_VAR^^}" == "ROLE") ||
+                    ((-n ${AWS_CRED_AWS_ACCESS_KEY_ID}) && (-n ${AWS_CRED_AWS_SECRET_ACCESS_KEY})) ]]; then
+                    TEMP_CREDENTIAL_FILE="${AUTOMATION_DATA_DIR}/temp_aws_credentials.json"
+                    unset AWS_SESSION_TOKEN
+
+                    aws sts assume-role \
+                        --role-arn arn:aws:iam::${!AWS_CRED_AWS_ACCOUNT_ID_VAR}:role/${AWS_CRED_AUTOMATION_ROLE} \
+                        --role-session-name "$(echo $GIT_USER | tr -cd '[[:alnum:]]' )" \
+                        --duration-seconds "${AUTOMATION_ROLE_VALIDITY}" \
+                        --output json > ${TEMP_CREDENTIAL_FILE} ||
+                        aws sts assume-role \
+                            --role-arn arn:aws:iam::${!AWS_CRED_AWS_ACCOUNT_ID_VAR}:role/${AWS_CRED_AUTOMATION_ROLE} \
+                            --role-session-name "$(echo $GIT_USER | tr -cd '[[:alnum:]]' )" \
+                            --output json > ${TEMP_CREDENTIAL_FILE}
+                    unset AWS_ACCESS_KEY_ID
+                    unset AWS_SECRET_ACCESS_KEY
+                    AWS_CRED_TEMP_AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' < ${TEMP_CREDENTIAL_FILE})
+                    AWS_CRED_TEMP_AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' < ${TEMP_CREDENTIAL_FILE})
+                    AWS_CRED_TEMP_AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' < ${TEMP_CREDENTIAL_FILE})
+                    rm ${TEMP_CREDENTIAL_FILE}
+                fi
             fi
         fi
+        ;;
 
-        if [[ ("${!AWS_CRED_AUTOMATION_USER_VAR^^}" == "ROLE") ||
-              ((-n ${AWS_CRED_AWS_ACCESS_KEY_ID}) && (-n ${AWS_CRED_AWS_SECRET_ACCESS_KEY})) ]]; then
-            TEMP_CREDENTIAL_FILE="${AUTOMATION_DATA_DIR}/temp_aws_credentials.json"
-            unset AWS_SESSION_TOKEN
+    azure)
 
-            aws sts assume-role \
-                --role-arn arn:aws:iam::${!AWS_CRED_AWS_ACCOUNT_ID_VAR}:role/${AWS_CRED_AUTOMATION_ROLE} \
-                --role-session-name "$(echo $GIT_USER | tr -cd '[[:alnum:]]' )" \
-                --duration-seconds "${AUTOMATION_ROLE_VALIDITY}" \
-                --output json > ${TEMP_CREDENTIAL_FILE} ||
-                aws sts assume-role \
-                    --role-arn arn:aws:iam::${!AWS_CRED_AWS_ACCOUNT_ID_VAR}:role/${AWS_CRED_AUTOMATION_ROLE} \
-                    --role-session-name "$(echo $GIT_USER | tr -cd '[[:alnum:]]' )" \
-                    --output json > ${TEMP_CREDENTIAL_FILE}
-            unset AWS_ACCESS_KEY_ID
-            unset AWS_SECRET_ACCESS_KEY
-            AWS_CRED_TEMP_AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' < ${TEMP_CREDENTIAL_FILE})
-            AWS_CRED_TEMP_AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' < ${TEMP_CREDENTIAL_FILE})
-            AWS_CRED_TEMP_AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' < ${TEMP_CREDENTIAL_FILE})
-            rm ${TEMP_CREDENTIAL_FILE}
+        # find the method - default to prompt based login
+        AZ_AUTOMATION_AUTH_METHOD_VAR="${CRED_ACCOUNT}_AZ_AUTH_METHOD"
+        if [[ -z "${!AZ_AUTOMATION_AUTH_METHOD_VAR}" ]]; then AZ_AUTOMATION_AUTH_METHOD_VAR="AZ_AUTH_METHOD"; fi
+        AZ_AUTH_METHOD="${!AZ_AUTOMATION_AUTH_METHOD_VAR:-interactive}"
+
+        # lookup the AZ Account
+        AZ_ACCOUNT_ID_VAR="${CRED_ACCOUNT}_AZ_ACCOUNT_ID"
+        if [[ -n "${!AZ_ACCOUNT_ID_VAR}" ]]; then
+            AZ_ACCOUNT_ID="${AZ_ACCOUNT_ID_VAR}"
         fi
-    fi
-fi
+
+        # Set the tenant - this can be account specific but most likely global
+        AZ_ACCOUNT_TENANT_OVERRIDE_VAR="${CRED_ACCOUNT}_AZ_TENANT_ID"
+        if [[ -n "${!AZ_ACCOUNT_TENANT_OVERRIDE_VAR}" ]]; then
+            AZ_TENANT_ID="${AZ_ACCOUNT_TENANT_OVERRIDE_VAR}"
+        fi
+
+        case "${AZ_AUTH_METHOD}" in
+            service)
+
+                #Account specific creds
+                AZ_CRED_OVERRIDE_USERNAME_VAR="${CRED_ACCOUNT}_AZ_USERNAME"
+                AZ_CRED_OVERRIDE_PASS_VAR="${CRED_ACCOUNT}_AZ_PASS"
+
+                if [[ ( -n "${!AZ_CRED_OVERRIDE_USERNAME_VAR}") && (-n "${!AZ_CRED_OVERRIDE_PASS_VAR}") ]]; then
+                    AZ_CRED_USERNAME="${AZ_CRED_OVERRIDE_USERNAME_VAR}"
+                    AZ_CRED_PASS="${AZ_CRED_OVERRIDE_PASS_VAR}"
+                else
+
+                    # Tenant wide credentials
+                    AZ_CRED_AUTOMATION_USERNAME_VAR="${CRED_ACCOUNT}_AUTOMATION_USER"
+                    if [[ -z "${!AZ_CRED_AUTOMATION_USERNAME_VAR}" ]]; then AZ_CRED_AUTOMATION_USERNAME_VAR="AZ_AUTOMATION_USER" ; fi
+
+                    if  [[ -n "${!AWS_CRED_AUTOMATION_USER_VAR}" ]]; then
+                        AZ_CRED_USERNAME="${AZ_CRED_AUTOMATION_USERNAME_VAR}_AZ_USERNAME"
+                        AZ_CRED_PASS="${AZ_CRED_AUTOMATION_USERNAME_VAR}_AZ_PASS"
+                    fi
+                fi
+
+                az login --service-principal --username "${AZ_CRED_USERNAME}" --password "${AZ_CRED_PASS}" --tenant "${AZ_TENANT_ID}"
+
+                ;;
+
+            managed)
+                az login --identity
+                ;;
+
+            interactive)
+                az login
+                ;;
+        esac
+
+        az account set --subscription "${AZ_ACCOUNT_ID}"
+        ;;
+esac

--- a/automation/jenkins/aws/setCredentials.sh
+++ b/automation/jenkins/aws/setCredentials.sh
@@ -12,7 +12,7 @@ CRED_ACCOUNT="${1^^}"
 
 CRED_ACCOUNT_CLOUD_PROVIDER_VAR="${CRED_ACCOUNT}_CLOUD_PROVIDER"
 
-if [[ -z "${CRED_ACCOUNT_PROVIDER_VAR}" ]]; then
+if [[ -z "${CRED_ACCOUNT_CLOUD_PROVIDER_VAR}" ]]; then
     if [[ -n "${AZID}" ]]; then
         CLOUD_PROVIDER="azure"
     else

--- a/cli/manageDeployment.sh
+++ b/cli/manageDeployment.sh
@@ -11,7 +11,6 @@ DEPLOYMENT_MONITOR_DEFAULT="true"
 DEPLOYMENT_OPERATION_DEFAULT="update"
 DEPLOYMENT_WAIT_DEFAULT=30
 DEPLOYMENT_SCOPE_DEFAULT="resourceGroup"
-RESOURCE_GROUP_DEFAULT="default"
 
 function usage() {
   cat <<EOF
@@ -23,7 +22,7 @@ function usage() {
   where
 
   (o) -d (DEPLOYMENT_OPERATION=delete)  to delete the deployment
-  (o) -g RESOURCE_GROUP                 Defines the Resource Group to deploy into. Mandatory with DEPLOYMENT_SCOPE as "resourceGroup".
+  (o) -g RESOURCE_GROUP                 Overrides the Resource Group to deploy into, default is to generate a deployment group per deployment unit
       -h                                shows this text
   (o) -i (DEPLOYMENT_MONITOR=false)     initiates but does not monitor the deployment operation.
   (m) -l LEVEL                          is the deployment level - "account", "product", "segment", "solution", "application" or "multiple"
@@ -43,7 +42,6 @@ function usage() {
   DEPLOYMENT_OPERATION = ${DEPLOYMENT_OPERATION_DEFAULT}
   DEPLOYMENT_WAIT      = ${DEPLOYMENT_WAIT_DEFAULT} seconds
   DEPLOYMENT_SCOPE     = ${DEPLOYMENT_SCOPE_DEFAULT}
-  RESOURCE_GROUP       = ${RESOURCE_GROUP_DEFAULT}
 
 EOF
 }
@@ -75,7 +73,6 @@ function options() {
   DEPLOYMENT_INITIATE=${DEPLOYMENT_INITIATE:-${DEPLOYMENT_INITIATE_DEFAULT}}
   DEPLOYMENT_MONITOR=${DEPLOYMENT_MONITOR:-${DEPLOYMENT_MONITOR_DEFAULT}}
   DEPLOYMENT_SCOPE=${DEPLOYMENT_SCOPE:-${DEPLOYMENT_SCOPE_DEFAULT}}
-  RESOURCE_GROUP=${RESOURCE_GROUP:-${RESOURCE_GROUP_DEFAULT}}
 
   # Add component suffix to the deployment name.
   if [[ -n "${DEPLOYMENT_UNIT_SUBSET}" ]]; then
@@ -87,6 +84,8 @@ function options() {
   # Set up the context
   info "Preparing the context..."
   . "${GENERATION_BASE_DIR}/execution/setStackContext.sh"
+
+  RESOURCE_GROUP=${RESOURCE_GROUP:-${STACK_NAME}}
 
   return 0
 }

--- a/execution/setContext.sh
+++ b/execution/setContext.sh
@@ -193,6 +193,7 @@ if [[ "${GENERATION_INPUT_SOURCE}" == "composite" ]]; then
     export TENANT=${TENANT:-$(runJQ -r '.Tenant.Name | select(.!="Tenant") | select(.!=null)' < ${COMPOSITE_BLUEPRINT})}
     export AID=${AID:-$(runJQ -r '.Account.Id | select(.!="Account") | select(.!=null)' < ${COMPOSITE_BLUEPRINT})}
     export AWSID=${AWSID:-$(runJQ -r '.Account.AWSId | select(.!=null)' < ${COMPOSITE_BLUEPRINT})}
+    export AZID=${AZID:-$(runJQ -r '.Account.AzureId | select(.!=null)' < ${COMPOSITE_BLUEPRINT})}
     export ACCOUNT_REGION=${ACCOUNT_REGION:-$(runJQ -r '.Account.Region | select(.!=null)' < ${COMPOSITE_BLUEPRINT})}
     export PID=${PID:-$(runJQ -r '.Product.Id | select(.!="Product") | select(.!=null)' < ${COMPOSITE_BLUEPRINT})}
     export PRODUCT_REGION=${PRODUCT_REGION:-$(runJQ -r '.Product.Region | select(.!=null)' < ${COMPOSITE_BLUEPRINT})}
@@ -264,6 +265,18 @@ if [[ ((-z "${AWS_ACCESS_KEY_ID}") || (-z "${AWS_SECRET_ACCESS_KEY}")) ]]; then
             export AWS_DEFAULT_PROFILE="${AWSID}"
         fi
     fi
+fi
+
+# Set the Azure subscription and login
+if [[ -n "${AZID}" ]]; then
+
+    if [[ -z "$(az account list --output tsv)" ]]; then
+        info "Logging in to Azure..."
+        . ${AUTOMATION_DIR}/setCredentials.sh "${ACCOUNT}"
+
+    fi
+
+    az account set --subscription "${AZID}" --output none
 fi
 
 # Handle some MINGW peculiarities

--- a/execution/setContext.sh
+++ b/execution/setContext.sh
@@ -267,16 +267,14 @@ if [[ ((-z "${AWS_ACCESS_KEY_ID}") || (-z "${AWS_SECRET_ACCESS_KEY}")) ]]; then
     fi
 fi
 
-# Set the Azure subscription and login
+# Set the Azure subscription and login if we haven't already
 if [[ -n "${AZID}" ]]; then
-
     if [[ -z "$(az account list --output tsv)" ]]; then
         info "Logging in to Azure..."
         . ${AUTOMATION_DIR}/setCredentials.sh "${ACCOUNT}"
 
     fi
-
-    az account set --subscription "${AZID}" --output none
+    az account set --subscription "${AZID}" --output none || exit $?
 fi
 
 # Handle some MINGW peculiarities

--- a/execution/setStackContext.sh
+++ b/execution/setStackContext.sh
@@ -175,8 +175,13 @@ if [[ ! -f "${CF_DIR}/${TEMPLATE}" ]]; then
 fi
 
 # Permit renaming of stack files without affecting existing stack status
-if [[ -f "${CF_DIR}/${STACK}" ]]; then
+if [[ -f "${CF_DIR}/${STACK}" && -n "${AWSID}" ]]; then
     STACK_NAME=$(jq -r ".Stacks[0].StackName" <  "${CF_DIR}/${STACK}")
+fi
+
+# Permit renaming of stack files without affecting existing stack status
+if [[ -f "${CF_DIR}/${STACK}" && -n "${AZID}" ]]; then
+    STACK_NAME=$(jq -r ".properties.outputs.resourceGroup.value" <  "${CF_DIR}/${STACK}")
 fi
 
 ALTERNATIVE_TEMPLATES=$(findFiles \


### PR DESCRIPTION
## Description
Adds support for managing azure logins and setting the active subscription 
- Allows for specifying the authentication source as managed-identity, interactive or service-principal. These can be set by environment variables with the default action as interactive 
- uses the existing stack name generation to set a default resource group. Also checks what the current resource group name is to support the current resource group override

## Motivation and Context
This is to support running templates from a automated process and to align with the similar behaviour we for the the AWS execution

## How Has This Been Tested?
Tested locally with both aws and azure deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
