### PR TITLE
fix(azure): allow for running local deployments with context

### DIFF
--- a/execution/setContext.sh
+++ b/execution/setContext.sh
@@ -274,7 +274,7 @@ if [[ -n "${AZID}" ]]; then
         . ${AUTOMATION_DIR}/setCredentials.sh "${ACCOUNT}"
 
     fi
-    az account set --subscription "${AZID}" --output none || exit $?
+    az account set --subscription "${AZID}" --output none
 fi
 
 # Handle some MINGW peculiarities


### PR DESCRIPTION
## Description
Remove failure when set context doesn't work

## Motivation and Context
To enable situations where a user wants to check template generation locally and they don't have access to the Azure Subscription that the deployment is deployed into. At the moment if this is the case templates can't be generated

## How Has This Been Tested?
Tested locally

## Types of changes
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
