### PR TITLE
fix: azure credentials lookup

### DIFF
--- a/automation/jenkins/aws/setCredentials.sh
+++ b/automation/jenkins/aws/setCredentials.sh
@@ -115,20 +115,17 @@ case "${ACCOUNT_PROVIDER}" in
                 AZ_CRED_OVERRIDE_USERNAME_VAR="${CRED_ACCOUNT}_AZ_USERNAME"
                 AZ_CRED_OVERRIDE_PASS_VAR="${CRED_ACCOUNT}_AZ_PASS"
 
-                if [[ ( -n "${!AZ_CRED_OVERRIDE_USERNAME_VAR}") && (-n "${!AZ_CRED_OVERRIDE_PASS_VAR}") ]]; then
+                if [[ ( -n "${!AZ_CRED_OVERRIDE_USERNAME_VAR}") ]]; then
                     AZ_CRED_USERNAME="${AZ_CRED_OVERRIDE_USERNAME_VAR}"
                     AZ_CRED_PASS="${AZ_CRED_OVERRIDE_PASS_VAR}"
                 else
 
                     # Tenant wide credentials
-                    AZ_CRED_AUTOMATION_USERNAME_VAR="${CRED_ACCOUNT}_AUTOMATION_USER"
+                    AZ_CRED_AUTOMATION_USERNAME_VAR="AZ_USERNAME"
+                    AZ_CRED_AUTOTMATION_PASS_VAR="AZ_PASS"
                     if [[ -z "${!AZ_CRED_AUTOMATION_USERNAME_VAR}" ]]; then
-                        AZ_CRED_AUTOMATION_USERNAME_VAR="AZ_AUTOMATION_USER"
-                    fi
-
-                    if  [[ -n "${!AZ_CRED_AUTOMATION_USERNAME_VAR}" ]]; then
-                        AZ_CRED_USERNAME="${AZ_CRED_AUTOMATION_USERNAME_VAR}_AZ_USERNAME"
-                        AZ_CRED_PASS="${AZ_CRED_AUTOMATION_USERNAME_VAR}_AZ_PASS"
+                        AZ_CRED_USERNAME="${AZ_CRED_AUTOMATION_USERNAME_VAR}"
+                        AZ_CRED_PASS="${AZ_CRED_AUTOTMATION_PASS_VAR}"
                     fi
                 fi
 


### PR DESCRIPTION
## Description
Cleanup azure credentials lookup, should just have two levels, account specific and tenant

## Motivation and Context
When this was originally setup it followed the AWS standard a bit to much which has an extra layer to lookup username from AWS keys which isn't in Azure

## How Has This Been Tested?
Tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
