### PR TITLE
fix(azure): use provider to set manage command

### DIFF
--- a/automation/jenkins/aws/manageUnits.sh
+++ b/automation/jenkins/aws/manageUnits.sh
@@ -147,22 +147,30 @@ function main() {
         # Manage the stack if required
         if [[ -n "${DEPLOYMENT_MODE}" ]]; then
           if [[ "${DEPLOYMENT_MODE}" == "${DEPLOYMENT_MODE_STOP}" || "${DEPLOYMENT_MODE}" == "${DEPLOYMENT_MODE_STOPSTART}" ]]; then
-              if [[ -n "${AZID}" ]]; then
-                ${GENERATION_DIR}/manageDeployment.sh -d -l "${level}" -u "${unit}" ||
+              case "${ACCOUNT_PROVIDER}" in
+                azure)
+                  ${GENERATION_DIR}/manageDeployment.sh -d -l "${level}" -u "${unit}" ||
                   { exit_status=$?; fatal "Deletion of the ${level} level deployment for the ${unit} deployment unit failed"; return "${exit_status}"; }
-              else
-                ${GENERATION_DIR}/manageStack.sh -d -l "${level}" -u "${unit}" ||
+                  ;;
+
+                *)
+                  ${GENERATION_DIR}/manageStack.sh -d -l "${level}" -u "${unit}" ||
                   { exit_status=$?; fatal "Deletion of the ${level} level stack for the ${unit} deployment unit failed"; return "${exit_status}"; }
-              fi
+                  ;;
+              esac
           fi
           if [[ "${DEPLOYMENT_MODE}" != "${DEPLOYMENT_MODE_STOP}"   ]]; then
-              if [[ -n "${AZID}" ]]; then
-                ${GENERATION_DIR}/manageDeployment.sh -l "${level}" -u "${unit}" ||
-                  { exit_status=$?; fatal "Create/update of the ${level} level stack for the ${unit} deployment unit failed"; return "${exit_status}"; }
-              else
-                ${GENERATION_DIR}/manageStack.sh -l "${level}" -u "${unit}" ||
-                  { exit_status=$?; fatal "Create/update of the ${level} level stack for the ${unit} deployment unit failed"; return "${exit_status}"; }
-              fi
+              case "${ACCOUNT_PROVIDER}" in
+                azure)
+                  ${GENERATION_DIR}/manageDeployment.sh -l "${level}" -u "${unit}" ||
+                  { exit_status=$?; fatal "Deletion of the ${level} level deployment for the ${unit} deployment unit failed"; return "${exit_status}"; }
+                  ;;
+
+                *)
+                  ${GENERATION_DIR}/manageStack.sh -l "${level}" -u "${unit}" ||
+                  { exit_status=$?; fatal "Deletion of the ${level} level stack for the ${unit} deployment unit failed"; return "${exit_status}"; }
+                  ;;
+              esac
           fi
         fi
       done

--- a/automation/setContext.sh
+++ b/automation/setContext.sh
@@ -430,18 +430,22 @@ function main() {
 
   # - provider
   findAndDefineSetting "ACCOUNT_PROVIDER" "ACCOUNT_PROVIDER" "${ACCOUNT}" "" "value" "aws"
-  AUTOMATION_DIR="${AUTOMATION_PROVIDER_DIR}/${ACCOUNT_PROVIDER}"
-
 
   # - access credentials
   case "${ACCOUNT_PROVIDER}" in
       aws)
+          AUTOMATION_DIR="${AUTOMATION_PROVIDER_DIR}/${ACCOUNT_PROVIDER}"
           . ${AUTOMATION_DIR}/setCredentials.sh "${ACCOUNT}"
           save_context_property ACCOUNT_AWS_ACCESS_KEY_ID_VAR      "${AWS_CRED_AWS_ACCESS_KEY_ID_VAR}"
           save_context_property ACCOUNT_AWS_SECRET_ACCESS_KEY_VAR  "${AWS_CRED_AWS_SECRET_ACCESS_KEY_VAR}"
           save_context_property ACCOUNT_TEMP_AWS_ACCESS_KEY_ID     "${AWS_CRED_TEMP_AWS_ACCESS_KEY_ID}"
           save_context_property ACCOUNT_TEMP_AWS_SECRET_ACCESS_KEY "${AWS_CRED_TEMP_AWS_SECRET_ACCESS_KEY}"
           save_context_property ACCOUNT_TEMP_AWS_SESSION_TOKEN     "${AWS_CRED_TEMP_AWS_SESSION_TOKEN}"
+          ;;
+
+        azure)
+          AUTOMATION_DIR="${AUTOMATION_PROVIDER_DIR}/aws"
+          . ${AUTOMATION_DIR}/setCredentials.sh "${ACCOUNT}"
           ;;
   esac
 


### PR DESCRIPTION
## Description
Some minor fixes in manageUnit to use environment variables available during the automation phases ( AZID wouldn't be there as this is a generation side variable ) 

## Motivation and Context
Deployments would get the right credentials but used the wrong deployment script

## How Has This Been Tested?
Tested locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
