### PR TITLE
refactor: Reasonable defaults for CMK listing

### DIFF
--- a/cli/manageCrypto.sh
+++ b/cli/manageCrypto.sh
@@ -283,6 +283,11 @@ function main() {
             CRYPTO_VISIBLE="false"
             CRYPTO_DECODE="true"
             ;;
+        listcmk)
+            CRYPTO_VISIBLE="false"
+            CRYPTO_DECODE="true"
+            CRYPTO_UPDATE="false"
+            ;;
     esac
 
 
@@ -342,9 +347,6 @@ function main() {
                 --query "Aliases[0].AliasName")
             # List only - force settings accordingly
             CRYPTO_TEXT="ALIAS=${CMK_ALIAS#alias/} ARN=${CMK_ARN}"
-            CRYPTO_VISIBLE=false
-            CRYPTO_UPDATE=false
-            #
             ;;
         noop)
             # Don't touch CRYPTO_TEXT so either existing value will be displayed, or


### PR DESCRIPTION
## Description
When listing the current CMK under which ciphertext is encrypted, ensure a reasonable set of values are set for key other input parameters.

## Motivation and Context
For this command, some other command line options need to be set to specific values for the command to complete successfully, so force these values regardless of what the user did or didn't provide.

## How Has This Been Tested?
Local testing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
