### PR TITLE
refactor: Avoid duplicate unit listing

### DIFF
--- a/automation/jenkins/aws/manageBuildReferences.sh
+++ b/automation/jenkins/aws/manageBuildReferences.sh
@@ -75,23 +75,28 @@ function updateDetail() {
     local UD_FORMATS="${4,,:-?}"
     local UD_SCOPE="${5,,:-?}"
 
+    local DETAIL=""
+
     if [[ ("${UD_COMMIT}" != "?") || ("${UD_TAG}" != "?") ]]; then
-        DETAIL_MESSAGE="${DETAIL_MESSAGE}, ${UD_DEPLOYMENT_UNIT}="
+        DETAIL="${UD_DEPLOYMENT_UNIT}="
         if [[ "${UD_FORMATS}" != "?" ]]; then
-            DETAIL_MESSAGE="${DETAIL_MESSAGE}${UD_FORMATS}:"
+            DETAIL="${DETAIL}${UD_FORMATS}:"
         fi
         if [[ "${UD_TAG}" != "?" ]]; then
             # Format is tag then commit if provided
-            DETAIL_MESSAGE="${DETAIL_MESSAGE}${UD_TAG}"
+            DETAIL="${DETAIL}${UD_TAG}"
             if [[ "${UD_COMMIT}" != "?" ]]; then
-                DETAIL_MESSAGE="${DETAIL_MESSAGE} (${UD_COMMIT:0:7})"
+                DETAIL="${DETAIL} (${UD_COMMIT:0:7})"
             fi
         else
             # Format is just the commit
-            DETAIL_MESSAGE="${DETAIL_MESSAGE}${UD_COMMIT:0:7}"
+            DETAIL="${DETAIL}${UD_COMMIT:0:7}"
         fi
         if [[ "${UD_SCOPE}" != "?" ]]; then
-            DETAIL_MESSAGE="${DETAIL_MESSAGE}:${UD_SCOPE}"
+            DETAIL="${DETAIL}:${UD_SCOPE}"
+        fi
+        if [[ ! ("${DETAIL_MESSAGE}" =~ ${DETAIL}) ]]; then
+            DETAIL_MESSAGE="${DETAIL_MESSAGE}, ${DETAIL}"
         fi
     fi
 }


### PR DESCRIPTION
Check if the detail message already contains the unit detail to ensure it isn't added more than once.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
This is mainly to support the Jenkinsfiles where the update build references and deploys are don in the same build, so currently the unit detail is included twice.

## How Has This Been Tested?
Customer deployments

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
