### PR TITLE
feat: CMDB Upgrades via pinning

### DIFF
--- a/execution/contextTree.sh
+++ b/execution/contextTree.sh
@@ -1757,6 +1757,15 @@ function process_cmdb() {
 
     [[ -z "${current_version}" ]] && current_version="v0.0.0"
 
+    # Support forcing updates by adjusting the pinned values
+    if [[ -n "${pin_version}" ]]; then
+      local pin_check="$(semver_compare "${pin_version}" "${current_version}")"
+      if [[ "${pin_check}" == "1" ]]; then
+        debug "${action^} of repo "${cmdb_repo}" to pinned version ${pin_version} required ..."
+        versions+=(${pin_version})
+      fi
+    fi
+
     # Most of the time we expect no upgrade to be required
     local last_check="$(semver_compare "${current_version}" "${versions[-1]}")"
     if [[ "${last_check}" != "-1" ]]; then


### PR DESCRIPTION
## Description
Support the ability to upgrade a cmdb via setting the pinned version to the desired version.

## Motivation and Context
Currently, the only way to force a cmdb version to a value greater than the framework default is by setting the GENERATION_MAX_CMDB_UPGRADE_VERSION variable. Adjusting the pinned value allows selective update of cmdbs.

## How Has This Been Tested?
Local deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
