### PR TITLE
fix: env lookup for segment account

### DIFF
--- a/automation/setContext.sh
+++ b/automation/setContext.sh
@@ -603,7 +603,7 @@ function main() {
           fi
 
           findAndDefineSetting "FROM_ACCOUNT" "ACCOUNT" "${PRODUCT}" "${FROM_ENVIRONMENT}" "value"
-          [[ -z "${FROM_ACCOUNT}" ]] && findAndDefineSetting "FROM_ACCOUNT" "ACCOUNT" "${PRODUCT}" "${ENVIRONMENT}_${SEGMENT}" "value"
+          [[ -z "${FROM_ACCOUNT}" ]] && findAndDefineSetting "FROM_ACCOUNT" "ACCOUNT" "${PRODUCT}" "${FROM_ENVIRONMENT}_${SEGMENT}" "value"
 
           if [[ (-n "${FROM_ENVIRONMENT}") &&
                   (-n "${FROM_ACCOUNT}")]]; then


### PR DESCRIPTION
## Description
Fixes the environment account lookup when using segment level accounts

## Motivation and Context
It wasn't working when only a segment level accounts were set

## How Has This Been Tested?
Tested on active deployment

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
