### PR TITLE
fix: set fastlane manifest URL to build format specific version

### DIFF
--- a/cli/runExpoAppPublish.sh
+++ b/cli/runExpoAppPublish.sh
@@ -397,7 +397,8 @@ function main() {
 
   # Create a build for the SDK
   info "Creating an OTA for this version of the SDK"
-  expo export --dump-sourcemap --public-url "${PUBLIC_URL}" --asset-url "${PUBLIC_ASSETS_URL}" --output-dir "${SRC_PATH}/app/dist/build/${EXPO_SDK_VERSION}"  || return $?
+  EXPO_VERSION_PUBLIC_URL="${PUBLIC_URL}/packages/${EXPO_SDK_VERSION}"
+  expo export --dump-sourcemap --public-url "${EXPO_VERSION_PUBLIC_URL}" --asset-url "${PUBLIC_ASSETS_PATH}" --output-dir "${SRC_PATH}/app/dist/build/${EXPO_SDK_VERSION}"  || return $?
 
   EXPO_ID_OVERRIDE="$( jq -r '.BuildConfig.EXPO_ID_OVERRIDE' < "${CONFIG_FILE}" )"
   if [[ "${EXPO_ID_OVERRIDE}" != "null" && -n "${EXPO_ID_OVERRIDE}" ]]; then
@@ -557,7 +558,7 @@ function main() {
                     # Bare workflow support (SDK 37+)
 
                     # Updates URL
-                    fastlane run set_info_plist_value path:"ios/${EXPO_PROJECT_SLUG}/Supporting/Expo.plist" key:EXUpdatesURL value:"${PUBLIC_URL}" || return $?
+                    fastlane run set_info_plist_value path:"ios/${EXPO_PROJECT_SLUG}/Supporting/Expo.plist" key:EXUpdatesURL value:"${EXPO_MANIFEST_URL}" || return $?
 
                     # SDK Version
                     fastlane run set_info_plist_value path:"ios/${EXPO_PROJECT_SLUG}/Supporting/Expo.plist" key:EXUpdatesSDKVersion value:"${EXPO_SDK_VERSION}" || return $?


### PR DESCRIPTION
## Description
Updates the expo manifest file for fastlane builds to the explicit build format and SDK version based manifest file 


## Motivation and Context
When specifying the manifest file in plist files for IOS the path to the manifest is to the actual manifest file rather than the directory containing the manifest like it is for the expo app.json 

## How Has This Been Tested?
TEsted locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
