### PR TITLE
feat(azure): disable login if cant access subscription

### DIFF
--- a/automation/jenkins/aws/setCredentials.sh
+++ b/automation/jenkins/aws/setCredentials.sh
@@ -153,6 +153,10 @@ case "${ACCOUNT_PROVIDER}" in
             interactive)
                 az login "${az_login_args[@]}"
                 ;;
+
+            none)
+                info "Skipping Login to Azure - AZ_AUTH_METHOD = ${AZ_AUTH_METHOD}"
+                ;;
         esac
         ;;
 esac

--- a/cli/manageDeployment.sh
+++ b/cli/manageDeployment.sh
@@ -343,4 +343,4 @@ function main() {
   return 0
 }
 
-main "$@" || true
+main "$@"

--- a/execution/setContext.sh
+++ b/execution/setContext.sh
@@ -275,21 +275,27 @@ fi
 
 # Set the Azure subscription and login if we haven't already
 if [[ -n "${AZID}" ]]; then
-    if [[ -z "$(az account list --output tsv)" ]]; then
-        info "Logging in to Azure..."
-        . ${AUTOMATION_DIR}/setCredentials.sh "${ACCOUNT}"
-
-    fi
-
-    az_cli_args=()
-    # -- Only show errors unless debugging --
-    if willLog "${LOG_LEVEL_DEBUG}"; then
-        az_cli_args+=("--output" "json" )
+    if [[ "${AZ_AUTH_METHOD}" == "none" ]]; then
+        info "Skipping azure authentication - AZ_AUTH_METHOD=${AZ_AUTH_METHOD}"
     else
-        az_cli_args+=("--output" "none" )
-    fi
+        if [[ -z "$(az account list --output tsv)" ]]; then
+            info "Logging in to Azure..."
+            . ${AUTOMATION_DIR}/setCredentials.sh "${ACCOUNT}"
 
-    az account set --subscription "${AZID}" "${az_cli_args[@]}"
+        fi
+
+        if [[ "${AZ_AUTH_METHOD}" != "none" ]]; then
+            az_cli_args=()
+            # -- Only show errors unless debugging --
+            if willLog "${LOG_LEVEL_DEBUG}"; then
+                az_cli_args+=("--output" "json" )
+            else
+                az_cli_args+=("--output" "none" )
+            fi
+
+            az account set --subscription "${AZID}" "${az_cli_args[@]}"
+        fi
+    fi
 fi
 
 # Handle some MINGW peculiarities


### PR DESCRIPTION
## Description
Adds an AZ_AUTH_METHOD of none which skips the azure login process

## Motivation and Context
This is mainly for local testing where you might not be able to access the azure account from the machine you are doing local testing on. When using the default interactive login the screen will lock until you proceed

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
