### PR TITLE
feat(expo): publish otas under app major version

### DIFF
--- a/cli/runExpoAppPublish.sh
+++ b/cli/runExpoAppPublish.sh
@@ -460,7 +460,6 @@ function main() {
     aws --region "${AWS_REGION}" s3 sync --no-progress "${SRC_PATH}/app/dist/multi/" "s3://${PUBLIC_BUCKET}/${PUBLIC_PREFIX}/multi" || return $?
   fi
 
-   DETAILED_HTML_QR_MESSAGE="<h4>Expo Client App QR Codes</h4> <p>Use these codes to load the app through the Expo Client</p>"
    DETAILED_HTML_BINARY_MESSAGE="<h4>Expo Binary Builds</h4>"
    if [[ "${BUILD_BINARY}" == "false" ]]; then
      DETAILED_HTML_BINARY_MESSAGE="${DETAILED_HTML_BINARY_MESSAGE} <p> No binary builds were generated for this publish </p>"
@@ -670,6 +669,8 @@ function main() {
   DETAILED_HTML="<html><body> <h4>Expo Mobile App Publish</h4> <p> A new Expo mobile app publish has completed </p> <ul>"
 
   if [[ "${BINARY_BUILD_PROCESS}" == "turtle" ]]; then
+
+    DETAILED_HTML_QR_MESSAGE="<h4>Expo Client App QR Codes</h4> <p>Use these codes to load the app through the Expo Client</p>"
     for qr_build_format in "${EXPO_QR_BUILD_FORMATS[@]}"; do
 
         #Generate EXPO QR Code

--- a/cli/runExpoAppPublish.sh
+++ b/cli/runExpoAppPublish.sh
@@ -393,9 +393,9 @@ function main() {
   fi
 
   # Create base OTA
-  info "Creating an OTA | App Version: ${EXPO_APP_MAJOR_VERSION} | SDK: ${EXPO_SDJ_VERSION}"
+  info "Creating an OTA | App Version: ${EXPO_APP_MAJOR_VERSION} | SDK: ${EXPO_SDK_VERSION}"
   EXPO_VERSION_PUBLIC_URL="${PUBLIC_URL}/packages/${EXPO_APP_MAJOR_VERSION}/${EXPO_SDK_VERSION}"
-  expo export --dump-sourcemap --public-url "${EXPO_VERSION_PUBLIC_URL}" --asset-url "${PUBLIC_ASSETS_PATH}" --output-dir "${SRC_PATH}/app/dist/build/${EXPO_APP_MAJOR_VERSION}/${EXPO_SDK_VERSION}"  || return $?
+  expo export --dump-sourcemap --public-url "${EXPO_VERSION_PUBLIC_URL}" --asset-url "${PUBLIC_ASSETS_PATH}" --output-dir "${SRC_PATH}/app/dist/build/${EXPO_SDK_VERSION}"  || return $?
 
   EXPO_ID_OVERRIDE="$( jq -r '.BuildConfig.EXPO_ID_OVERRIDE' < "${CONFIG_FILE}" )"
   if [[ "${EXPO_ID_OVERRIDE}" != "null" && -n "${EXPO_ID_OVERRIDE}" ]]; then


### PR DESCRIPTION
## Description
A collection of fixes in the expo publish process 
- Adds the major version of the app into the manifest location  on fastlane builds. This allows for breaking changes to be rolled out gradually ( introduce breaking changes in a new major app version, then as the binary is rolled out they will be come available ) 
- Only run the multi manfiest builds for turtle based builds  - the different SDK/multimanifest support only works with the expo client which only works with turtle 
- Remove QR codes from the fastlane builds as they don't work

## Motivation and Context
To support safer deployment of apps built using expo and reduce the time to publish apps

## How Has This Been Tested?
Tested on an active deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- **NOTE** the move to a new OTA location means that new binaries will need to be distributed to receive the latest update 

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
