### PR TITLE
refactor: replace script with cfn account template for service linked roles

### DIFF
--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -828,17 +828,6 @@ function manage_iam_userpassword() {
   return 0
 }
 
-function create_iam_service_linked_role() {
-    local region="$1"; shift
-    local serviceName="$1"; shift
-
-    if [[ -z "$( aws --region "${region}" iam list-roles --path-prefix "/aws-service-role/${serviceName}/" --query "Roles[*].Arn" --output text )" ]]; then
-      aws --region "${region}" iam create-service-linked-role --aws-service-name "${serviceName}"
-    else
-      info "Service linked role ${serviceName} already exists"
-    fi
-}
-
 # -- CloudWatch Events --
 function delete_cloudwatch_event() {
     local region="$1"; shift


### PR DESCRIPTION
## Description
Removes the bash utility for service linked roles 

## Motivation and Context
Now maintained using an account level cloudformation template

## How Has This Been Tested?
tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [ ] engine - https://github.com/hamlet-io/engine/pull/1368
- [ ] engine-plugin-aws - https://github.com/hamlet-io/engine-plugin-aws/pull/107
- [ ] executor-bash - https://github.com/hamlet-io/executor-bash/pull/75
## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
