### PR TITLE
feat(filetransfer): security group management for filetransfer

### DIFF
--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -1675,6 +1675,37 @@ function cleanup_ssm_document() {
   fi
 }
 
+# -- Transfer --
+function manage_transfer_security_groups() {
+    local region="$1"; shift
+    local operation="$1"; shift
+    local cfnStackName="$1"; shift
+    local securityGroupId="$1"; shift
+    local transferServerId="$1"; shift
+
+    securityGroup="$(get_cloudformation_stack_output "${region}" "${cfnStackName}" "${securityGroupId}" "ref" || return $?)"
+    defaultSecurityGroup="$( aws --region "${region}" ec2 describe-security-groups --filter Name=group-name,Values=default --query 'SecurityGroups[0].GroupId' --output text || return $?)"
+
+    transferServer="$(get_cloudformation_stack_output "${region}" "${cfnStackName}" "${transferServerId}" "name" || return $?)"
+    vpcEndpoint="$( aws --region "${region}" transfer describe-server --server-id "${transferServer}" --query 'Server.EndpointDetails.VpcEndpointId' --output text || return $?)"
+
+    case ${operation} in
+      delete)
+        if [[ -n "${defaultSecurityGroup}" ]]; then
+          aws --region "${region}" ec2 modify-vpc-endpoint --vpc-endpoint-id "${vpcEndpoint}" --add-security-group-ids "${defaultSecurityGroup}" --output text || return $?
+        fi
+        aws --region "${region}" ec2 modify-vpc-endpoint --vpc-endpoint-id "${vpcEndpoint}" --remove-security-group-ids "${securityGroup}" --output text || return $?
+        ;;
+
+      update|create)
+        aws --region "${region}" ec2 modify-vpc-endpoint --vpc-endpoint-id "${vpcEndpoint}" --add-security-group-ids "${securityGroup}" --output text || return $?
+        if [[ -n "${defaultSecurityGroup}" ]]; then
+          aws --region "${region}" ec2 modify-vpc-endpoint --vpc-endpoint-id "${vpcEndpoint}" --remove-security-group-ids "${defaultSecurityGroup}" --output text || return $?
+        fi
+        ;;
+    esac
+}
+
 # -- Transit Gateway --
 
 function get_transitgateway_vpn_attachment() {


### PR DESCRIPTION
## Description
Adds a utility function to assign an appropriate security group to the filetransfer VPC Endpoint

## Motivation and Context
Currently when the AWS Transfer VPC Endpoint is provisioned it defaults to using the default VPC Security group which doesn't allow inbound access to the service and can't be managed from Cloud formation. This utility swaps the default security group for a security group created by hamlet during the template deployment process

## How Has This Been Tested?
Tested locally 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- executor-bash : https://github.com/hamlet-io/executor-bash/pull/76
- engine: https://github.com/hamlet-io/engine/pull/1369
- engine-plugin-aws: https://github.com/hamlet-io/engine-plugin-aws/pull/108

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
