### PR TITLE
fix: include fragment composite in unitlist generation

### DIFF
--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -344,6 +344,7 @@ function process_template_pass() {
 
     unitlist)
       local template="createUnitlist.ftl"
+      template_composites+=("FRAGMENT")
       # Blueprint applies across accounts and regions
       for p in "${pass_list[@]}"; do
         pass_account_prefix["${p}"]=""


### PR DESCRIPTION
## Description
include the fragment composite in unit list generation

## Motivation and Context
We now include fragment processing in the state of external components, since the unit list needs the state of each deployment unit the fragment needs to be processed as part of finding the deployment units

## How Has This Been Tested?
Tested locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
