### PR TITLE
fix: State tree deployment unit directory detection

### DIFF
--- a/execution/setStackContext.sh
+++ b/execution/setStackContext.sh
@@ -64,12 +64,17 @@ case $LEVEL in
         ;;
 esac
 
-# Adjust for deployment unit subdirectories
-readarray -t legacy_files < <(find "${CF_DIR}" -mindepth 1 -maxdepth 1 -name "*${DEPLOYMENT_UNIT}*" )
+# Check for "legacy" files i.e. deployment files that are still in the segment directory 
+legacy_files=()
+if [[ -d "${CF_DIR}" ]]; then
+    readarray -t legacy_files < <(find "${CF_DIR}" -mindepth 1 -maxdepth 1 -name "*${DEPLOYMENT_UNIT}*" )
+fi
 
+# Adjust for deployment unit subdirectories
 if [[ (-d "${CF_DIR}/${DEPLOYMENT_UNIT}") || "${#legacy_files[@]}" -eq 0 ]]; then
     CF_DIR=$(getUnitCFDir "${CF_DIR}" "${LEVEL}" "${DEPLOYMENT_UNIT}" "" "${REGION}" )
 fi
+
 
 case $LEVEL in
     account)


### PR DESCRIPTION
## Description
Add a check to ensure the find is not executed if the segment directory doesn't exist yet.

## Motivation and Context
Currently find throws an error the first time a unit is deployed to a segment.

## How Has This Been Tested?
Local deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
