### PR TITLE
Enable Dry Run for Azure Provider

### DIFF
--- a/automation/jenkins/aws/manageUnits.sh
+++ b/automation/jenkins/aws/manageUnits.sh
@@ -151,9 +151,8 @@ function main() {
           if [[ -n "${DRYRUN}" ]]; then
               case "${ACCOUNT_PROVIDER}" in
                 azure)
-                  # TODO: Confirm what plans generate from an Azure perspective
-                  # ${GENERATION_DIR}/manageDeployment.sh -y -q -l "${level}" -u "${unit}" ||
-                  # { exit_status=$?; fatal "Planning the ${level} level deployment for the ${unit} deployment unit failed"; return "${exit_status}"; }
+                  ${GENERATION_DIR}/manageDeployment.sh -y -q -l "${level}" -u "${unit}" ||
+                  { exit_status=$?; fatal "Planning the ${level} level deployment for the ${unit} deployment unit failed"; return "${exit_status}"; }
                   ;;
 
                 *)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Implements "Dry Run" and "Quiet" flags on the manageDeployment script used by the Azure provider. Dry Run provides the output of the Azure CLI "what-if" against a deployment, and in combination with the quiet flag, the output is also copied into a file for use with Hamlet Plans.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #72 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local template generation followed by testing with the `-q -y` flags. Also tested without them to ensure it wasn't impacted.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
