### PR TITLE
feat(aws): add support for ecs account settings

### DIFF
--- a/execution/contextTree.sh
+++ b/execution/contextTree.sh
@@ -727,7 +727,7 @@ function isValidUnit() {
   # Check unit if required
   if [[ "${unit_required[${level}]}" == "true" ]]; then
     # Default deployment units for each level
-    declare -ga ACCOUNT_UNITS_ARRAY=("cmk" "iam" "lg" "audit" "s3" "cert" "roles" "apigateway" "waf" "sms" "console" "volumeencrypt")
+    declare -ga ACCOUNT_UNITS_ARRAY=("cmk" "iam" "lg" "audit" "s3" "cert" "roles" "apigateway" "waf" "sms" "console" "volumeencrypt" "ecs")
     declare -ga PRODUCT_UNITS_ARRAY=("s3" "sns" "cert" "cmk")
     declare -ga BUILDBLUEPRINT_UNITS_ARRAY=(${unit})
     declare -ga APPLICATION_UNITS_ARRAY=(${unit})

--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -1257,6 +1257,15 @@ function manage_ec2_volume_encryption() {
 }
 
 #-- ECS --
+function manage_ecs_account_settings() {
+  local region="$1"; shift
+  local setting="$1"; shift
+  local state="$1"; shift
+
+  aws --region "${region}" ecs put-account-setting-default --name "${setting}" --value "${state}" || return $?
+  aws --region "${region}" ecs put-account-setting --name "${setting}" --value "${state}" || return $?
+}
+
 function create_ecs_scheduled_task() {
   local region="$1"; shift
   local ruleName="$1"; shift


### PR DESCRIPTION
## Description
bash executor implementation of https://github.com/hamlet-io/engine/pull/1393 

## Motivation and Context
Provides a utility to control the ECS account settings, it applies both the default ( if a more specific principal doesn't have the setting configured ) and also performs an override to an principals that currently have the settings applied. This ensures consistency across the deployment process

## How Has This Been Tested?
Tested on local active deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- engine - https://github.com/hamlet-io/engine/pull/1393
- executor-bash - https://github.com/hamlet-io/executor-bash/pull/85

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
