### PR TITLE
Testing Support fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *~
+
+.cache
+.build

--- a/cli/createReference.sh
+++ b/cli/createReference.sh
@@ -60,8 +60,8 @@ function process_template() {
   # of the account and product trees
   # The blueprint is handled specially as its logic is different to the others
 
-  local GENERATION_DATA_DIR="${GENERATION_BASE_DIR}/build/"
-  local CACHE_DIR="${GENERATION_BASE_DIR}/cache"
+  local GENERATION_DATA_DIR="${GENERATION_BASE_DIR}/.build/"
+  local CACHE_DIR="${GENERATION_BASE_DIR}/.cache"
   mkdir -p "${CACHE_DIR}"
 
   # Filename parts

--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -790,8 +790,7 @@ function process_template() {
   [[ ! -d ${cf_dir} ]] && mkdir -p ${cf_dir}
 
   # Create a random string to use as the run identifier
-  info "Creating run identifier ...\n"
-  run_id="$(dd bs=128 count=1 if=/dev/urandom  | base64 | env LC_CTYPE=C tr -dc 'a-z0-9' | fold -w 10 | head -n 1)"
+  run_id="$(dd bs=128 count=1 if=/dev/urandom status=none | base64 | env LC_CTYPE=C tr -dc 'a-z0-9' | fold -w 10 | head -n 1)"
 
   # Directory for temporary files
   pushTempDir "create_template_XXXXXX"

--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -762,13 +762,13 @@ function process_template() {
   #
   # The cleanup logic for >=2.0.1 cmdb is also more robust, as it will remove files
   # that are no longer generated.
-  local deployment_unit_state_subdirectories="false"
-  case "${level}" in
-    unitlist|blueprint|buildblueprint)
-      # No subdirectories for deployment units
-      ;;
-    *)
-      if [[ -d "${cf_dir_default}" ]]; then
+  if [[ -z "${OUTPUT_DIR}" ]]; then
+    local deployment_unit_state_subdirectories="false"
+    case "${level}" in
+      unitlist|blueprint|buildblueprint)
+        # No subdirectories for deployment units
+        ;;
+      *)
         readarray -t legacy_files < <(find "${cf_dir_default}" -mindepth 1 -maxdepth 1 -type f -name "*${deployment_unit}*" )
 
         if [[ (-d "${cf_dir_default}/${deployment_unit}") || "${#legacy_files[@]}" -eq 0 ]]; then
@@ -780,7 +780,8 @@ function process_template() {
         deployment_unit_state_subdirectories="true"
       fi
       ;;
-  esac
+    esac
+  fi
 
   # Permit an override
   cf_dir="${OUTPUT_DIR:-${cf_dir_default}}"

--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -769,11 +769,13 @@ function process_template() {
         # No subdirectories for deployment units
         ;;
       *)
-        readarray -t legacy_files < <(find "${cf_dir_default}" -mindepth 1 -maxdepth 1 -type f -name "*${deployment_unit}*" )
+        if [[ -d "${cf_dir_default}" ]]; then
+          readarray -t legacy_files < <(find "${cf_dir_default}" -mindepth 1 -maxdepth 1 -type f -name "*${deployment_unit}*" )
 
-        if [[ (-d "${cf_dir_default}/${deployment_unit}") || "${#legacy_files[@]}" -eq 0 ]]; then
-          local cf_dir_default=$(getUnitCFDir "${cf_dir_default}" "${level}" "${deployment_unit}" "" "${region}" )
-          deployment_unit_state_subdirectories="true"
+          if [[ (-d "${cf_dir_default}/${deployment_unit}") || "${#legacy_files[@]}" -eq 0 ]]; then
+            local cf_dir_default=$(getUnitCFDir "${cf_dir_default}" "${level}" "${deployment_unit}" "" "${region}" )
+            deployment_unit_state_subdirectories="true"
+          fi
         else
           local cf_dir_default=$(getUnitCFDir "${cf_dir_default}" "${level}" "${deployment_unit}" "" "${region}" )
           deployment_unit_state_subdirectories="true"

--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -211,6 +211,9 @@ function options() {
   # Specific input control for mock input
   if [[ "${GENERATION_INPUT_SOURCE}" == "mock" ]]; then
 
+    export CACHE_DIR="${GENERATION_BASE_DIR}/.cache"
+    mkdir -p "${CACHE_DIR}"
+
     if [[ -z "${OUTPUT_DIR}" ]]; then
       fatalMandatory
       return 1

--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -774,12 +774,11 @@ function process_template() {
         if [[ (-d "${cf_dir_default}/${deployment_unit}") || "${#legacy_files[@]}" -eq 0 ]]; then
           local cf_dir_default=$(getUnitCFDir "${cf_dir_default}" "${level}" "${deployment_unit}" "" "${region}" )
           deployment_unit_state_subdirectories="true"
+        else
+          local cf_dir_default=$(getUnitCFDir "${cf_dir_default}" "${level}" "${deployment_unit}" "" "${region}" )
+          deployment_unit_state_subdirectories="true"
         fi
-      else
-        local cf_dir_default=$(getUnitCFDir "${cf_dir_default}" "${level}" "${deployment_unit}" "" "${region}" )
-        deployment_unit_state_subdirectories="true"
-      fi
-      ;;
+        ;;
     esac
   fi
 


### PR DESCRIPTION
## Description

A collection of changes to support test generation with the mock input provider 
- Include the fragment file generation process as this is required to use the fragments which are part of the hamlet core code such as account fragments
- Support a cache dir that isn't part of the CMDB for mock input sources
- Add support for disabling the output cleanup process so that when using the OUTPUT_DIR parameter multiple deployment units can be staged in the same directory without being overridden 
- Don't enable deployment unit subdirectories when using the OUTPUT_DIR parameter 
- Cleanup output by removing dd status for run id generation

## Motivation and Context

This PR adds a collection of cleanups and features to handle the generation of mock input templates which are used for our testing suite. Before management contracts we couldn't throw an exception if template testing couldn't generate a template. As a result of this we missed some errors and potential issues when generating templates using the mock input provider. 

This hopes to fix them up and make template generation easier for testing


## How Has This Been Tested?
Tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
