### PR TITLE
Additional Error Handling

### DIFF
--- a/execution/setContext.sh
+++ b/execution/setContext.sh
@@ -210,6 +210,8 @@ if [[ "${GENERATION_INPUT_SOURCE}" == "composite" ]]; then
     fi
 
     # Perform a few consistency checks
+    [[ ! -s "${COMPOSITE_BLUEPRINT}" ]] && fatalCantProceed "The composite blueprint is empty. The likely cause of this is malformed JSON object in the Solution." && exit 1
+    
     [[ -z "${REGION}" ]] && fatalCantProceed "The region must be defined in the Product blueprint section." && exit 1
 
     BLUEPRINT_ACCOUNT=$(runJQ -r '.Account.Name | select(.!=null)' < ${COMPOSITE_BLUEPRINT})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds error handling that checks for an empty composite blueprint.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, if your JSON somewhere in the Solution is malformed (such as a missing a bracket), the error that reports is that the Region is undefined (because it can't find it in the composite blueprint). This will first check to see if the file has any content at all, and provide more accurate advice as to the cause.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local template generation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
