### PR TITLE
fix: More robust detection of stack completion

### DIFF
--- a/cli/manageStack.sh
+++ b/cli/manageStack.sh
@@ -144,7 +144,9 @@ function wait_for_stack_execution() {
         { fatal "Stack ${STACK_NAME} failed, fix stack before retrying"; exit_status=255; break;}
 
       # Finished if complete
-      egrep "(${operation_to_check})_COMPLETE\"" "${stack_status_file}" >/dev/null 2>&1 && \
+      # If the initial create was not saved for any reason, the stack may have a status of CREATE_COMPLETE
+      # even though the current operation is an UPDATE
+      egrep "(CREATE|UPDATE)_COMPLETE\"" "${stack_status_file}" >/dev/null 2>&1 && \
         { [[ -f "${potential_change_file}" ]] && cp "${potential_change_file}" "${CHANGE}"; break; }
 
       # Abort if not still in progress


### PR DESCRIPTION
## Description
Look for both CREATE_COMPLETE and UPDATE_COMPLETE when detecting if a stack completed successfully.

## Motivation and Context
Currently the logic looks for a specific COMPLETE status. However, if a create stack is not saved for whatever reason, and the stack creation is repeated, hamlet will look for an UPDATE when the stack output will still say CREATE_COMPLETE (assuming no changes result from rerunning the template).

## How Has This Been Tested?
Customer Site

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
