### PR TITLE
fix: Make warnings unique

### DIFF
--- a/cli/manageStack.sh
+++ b/cli/manageStack.sh
@@ -164,7 +164,7 @@ function wait_for_stack_execution() {
       0) ;;
       255)
         grep -q "No updates are to be performed" < "${stack_status_file}" &&
-          warning "No updates needed for stack ${STACK_NAME}. Treating as successful.\n"; break ||
+          warning "No updates needed for stack ${STACK_NAME} post change set execution. Treating as successful.\n"; break ||
           { cat "${stack_status_file}"; return ${exit_status}; }
       ;;
       *)
@@ -242,7 +242,7 @@ function process_stack() {
 
               cat "${potential_change_file}" | jq -r '.StatusReason' | grep -q "The submitted information didn't contain changes."; no_change=$?
               if [[ ${no_change} == 0 ]]; then
-                warning "No updates needed for stack ${STACK_NAME}. Treating as successful.\n"
+                warning "No updates needed for existing stack ${STACK_NAME}. Treating as successful.\n"
                 # Grab the latest stack in case it wasn't saved previously
                 aws --region ${REGION} cloudformation describe-stacks --stack-name "${STACK_NAME}" > "${STACK}"
               else
@@ -280,7 +280,7 @@ function process_stack() {
 
                       cat "${potential_change_file}" | jq -r '.StatusReason' | grep -q "The submitted information didn't contain changes."; no_change=$?
                       if [[ ${no_change} == 0 ]]; then
-                        warning "No updates needed for stack ${STACK_NAME}. Treating as successful.\n"
+                        warning "No updates needed for replacement stack ${STACK_NAME}. Treating as successful.\n"
                         # Grab the latest stack in case it wasn't saved previously
                         aws --region ${REGION} cloudformation describe-stacks --stack-name "${STACK_NAME}" > "${STACK}"
                       else


### PR DESCRIPTION
## Description
Make the message unique for each instance where we treat a change set as successfully completed.

## Motivation and Context
In order to make debugging easier.

## How Has This Been Tested?
Customer deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
