### PR TITLE
feat: "account" and fixed build scope

### DIFF
--- a/automation/jenkins/aws/manageDocker.sh
+++ b/automation/jenkins/aws/manageDocker.sh
@@ -250,7 +250,13 @@ DOCKER_OPERATION="${DOCKER_OPERATION:-${DOCKER_OPERATION_DEFAULT}}"
 DOCKER_PRODUCT="${DOCKER_PRODUCT:-${PRODUCT}}"
 
 # Handle registry scope values
+REGISTRY_SUBTYPE=""
 case "${REGISTRY_SCOPE}" in
+    account)
+        if [[ -n "${ACCOUNT}" ]]; then
+            DOCKER_PRODUCT="account"
+        fi
+        ;;
     segment)
         if [[ -n "${SEGMENT}" ]]; then
             REGISTRY_SUBTYPE="-${SEGMENT}"
@@ -259,7 +265,7 @@ case "${REGISTRY_SCOPE}" in
         fi
         ;;
     *)
-        REGISTRY_SUBTYPE=""
+        [[ "${REGISTRY_SCOPE:-unset}" != "unset" ]] && REGISTRY_SUBTYPE="-${REGISTRY_SCOPE}"
         ;;
 esac
 

--- a/automation/jenkins/aws/manageRdssnapshot.sh
+++ b/automation/jenkins/aws/manageRdssnapshot.sh
@@ -209,7 +209,13 @@ SNAPSHOT_OPERATION="${SNAPSHOT_OPERATION:-${SNAPSHOT_OPERATION_DEFAULT}}"
 SNAPSHOT_PRODUCT="${SNAPSHOT_PRODUCT:-${PRODUCT}}"
 
 # Handle registry scope values
+REGISTRY_SUBTYPE=""
 case "${REGISTRY_SCOPE}" in
+    account)
+        if [[ -n "${ACCOUNT}" ]]; then
+            SNAPSHOT_PRODUCT="account"
+        fi
+        ;;
     segment)
         if [[ -n "${SEGMENT}" ]]; then
             REGISTRY_SUBTYPE="-${SEGMENT}"
@@ -218,7 +224,7 @@ case "${REGISTRY_SCOPE}" in
         fi
         ;;
     *)
-        REGISTRY_SUBTYPE=""
+        [[ "${REGISTRY_SCOPE:-unset}" != "unset" ]] && REGISTRY_SUBTYPE="-${REGISTRY_SCOPE}"
         ;;
 esac
 

--- a/automation/jenkins/aws/manageS3Registry.sh
+++ b/automation/jenkins/aws/manageS3Registry.sh
@@ -302,7 +302,13 @@ REGISTRY_PRODUCT="${REGISTRY_PRODUCT:-${PRODUCT}}"
 REGISTRY_REMOVE_SOURCE="${REGISTRY_REMOVE_SOURCE:-${REGISTRY_REMOVE_SOURCE_DEFAULT}}"
 
 # Handle registry scope values
+REGISTRY_SUBTYPE=""
 case "${REGISTRY_SCOPE}" in
+    account)
+        if [[ -n "${ACCOUNT}" ]]; then
+            REGISTRY_PRODUCT="account"
+        fi
+        ;;
     segment)
         if [[ -n "${SEGMENT}" ]]; then
             REGISTRY_SUBTYPE="/${SEGMENT}"
@@ -311,7 +317,7 @@ case "${REGISTRY_SCOPE}" in
         fi
         ;;
     *)
-        REGISTRY_SUBTYPE=""
+        [[ "${REGISTRY_SCOPE:-unset}" != "unset" ]] && REGISTRY_SUBTYPE="/${REGISTRY_SCOPE}"
         ;;
 esac
 


### PR DESCRIPTION
## Description
Add support for a build scope of "account". This permits the same build to be referenced across multiple segments/environments in an account. It replaces the product identifier with the fixed value "account".

Also support for a fixed value build scope. This permits all segments in a product to reference the same build.

## Motivation and Context

The initial use case for account scope is for code units that are shared across multiple products in an account, such as lambda authorisers. 

For single product accounts, account and fixed scope achieve the same result. The choice is more to self-document the intention, i.e. across products (account) or within a product (fixed). A future extension would be to elevate account level to tenancy level, for enterprise wide functionality (lambda authorisers, virus scanning etc).

The additional scopes have been added to RDS snapshots and docker for consistency.

## How Has This Been Tested?
Local deployments

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] Release with https://github.com/hamlet-io/engine-plugin-aws/pull/129
- [x] Release with https://github.com/hamlet-io/engine/pull/1402

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
