### PR TITLE
refactor: scope/formats from shared build

### DIFF
--- a/automation/jenkins/aws/validateUpdateBuildReferenceParameters.sh
+++ b/automation/jenkins/aws/validateUpdateBuildReferenceParameters.sh
@@ -11,10 +11,6 @@ trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 [[ -z "${DEPLOYMENT_UNIT_LIST}" ]] &&
     fatal "Job requires at least one deployment unit" && exit
 
-# Ensure at least one deployment unit has been provided
-[[ ( -z "${IMAGE_FORMAT}" ) && ( -z "${IMAGE_FORMATS}" ) ]] &&
-    fatal "Job requires the image format used to package the build" && exit
-
 # All good
 RESULT=0
 

--- a/automation/jenkins/aws/validateUpdateBuildReferencesParameters.sh
+++ b/automation/jenkins/aws/validateUpdateBuildReferencesParameters.sh
@@ -11,10 +11,6 @@ trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 [[ -z "${DEPLOYMENT_UNIT_LIST}" ]] &&
     fatal "Job requires at least one deployment unit" && exit
 
-# Ensure at least one deployment unit has been provided
-[[ ( -z "${IMAGE_FORMAT}" ) && ( -z "${IMAGE_FORMATS}" ) ]] &&
-    fatal "Job requires the image format used to package the build" && exit
-
 # All good
 RESULT=0
 

--- a/execution/contextTree.sh
+++ b/execution/contextTree.sh
@@ -652,6 +652,7 @@ function findGen3Dirs() {
       if [[ -n "${segment}" ]]; then
         debug "SEGMENT_DIR=$(findGen3ProductEnvironmentSegmentDir "${root_dir}" "${product}" "${environment}" "${segment}")"
         declare -gx ${prefix}SEGMENT_SHARED_SETTINGS_DIR=$(getGen3Env   "PRODUCT_SETTINGS_DIR"   "${prefix}")/shared/${segment}
+        declare -gx ${prefix}SEGMENT_SHARED_BUILDS_DIR=$(getGen3Env     "PRODUCT_BUILDS_DIR"     "${prefix}")/shared/${segment}
         declare -gx ${prefix}SEGMENT_SHARED_SOLUTIONS_DIR=$(getGen3Env  "PRODUCT_SOLUTIONS_DIR"  "${prefix}")/shared/${segment}
         declare -gx ${prefix}SEGMENT_SHARED_OPERATIONS_DIR=$(getGen3Env "PRODUCT_OPERATIONS_DIR" "${prefix}")/shared/${segment}
 


### PR DESCRIPTION

## Description
Refactor the script based management of builds to permit the formats and scope for a build to be determined from a shared build file.

## Motivation and Context
This will mean that build.json files only need to contain the commit and optional tag, and formats/scopes need only be defined once as part of the solution via the shared build directory tree.

The freemarker engine already supports this approach. A planned change is to move build updates to inside the freemarker engine so this logic is contained in one place.

## How Has This Been Tested?
Client deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
