### PR TITLE
fix: ignore registry scope if not set

### DIFF
--- a/automation/jenkins/aws/manageDocker.sh
+++ b/automation/jenkins/aws/manageDocker.sh
@@ -265,7 +265,7 @@ case "${REGISTRY_SCOPE}" in
         fi
         ;;
     *)
-        [[ "${REGISTRY_SCOPE:-unset}" != "unset" ]] && REGISTRY_SUBTYPE="-${REGISTRY_SCOPE}"
+        [[ "${REGISTRY_SCOPE:-unset}" != "unset" && "${REGISTRY_SCOPE}" != "?" ]] && REGISTRY_SUBTYPE="-${REGISTRY_SCOPE}"
         ;;
 esac
 

--- a/automation/jenkins/aws/manageRdssnapshot.sh
+++ b/automation/jenkins/aws/manageRdssnapshot.sh
@@ -224,7 +224,7 @@ case "${REGISTRY_SCOPE}" in
         fi
         ;;
     *)
-        [[ "${REGISTRY_SCOPE:-unset}" != "unset" ]] && REGISTRY_SUBTYPE="-${REGISTRY_SCOPE}"
+        [[ "${REGISTRY_SCOPE:-unset}" != "unset" && "${REGISTRY_SCOPE}" != "?" ]] && REGISTRY_SUBTYPE="-${REGISTRY_SCOPE}"
         ;;
 esac
 

--- a/automation/jenkins/aws/manageS3Registry.sh
+++ b/automation/jenkins/aws/manageS3Registry.sh
@@ -317,7 +317,7 @@ case "${REGISTRY_SCOPE}" in
         fi
         ;;
     *)
-        [[ "${REGISTRY_SCOPE:-unset}" != "unset" ]] && REGISTRY_SUBTYPE="/${REGISTRY_SCOPE}"
+        [[ "${REGISTRY_SCOPE:-unset}" != "unset" && "${REGISTRY_SCOPE}" != "?" ]] && REGISTRY_SUBTYPE="/${REGISTRY_SCOPE}"
         ;;
 esac
 


### PR DESCRIPTION
## Description
Minor fix for #96 / #95  Which removes the scope from the registry path if it is either unset or unkown 


## Motivation and Context
When the scope isn't know it is currently being included as a ? in the artefact path

## How Has This Been Tested?
Can't currently test this without deployment

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
