### PR TITLE
feat: Support shared build.json and shared_build.json in the shared build tree

### DIFF
--- a/automation/jenkins/aws/manageBuildReferences.sh
+++ b/automation/jenkins/aws/manageBuildReferences.sh
@@ -329,12 +329,15 @@ for ((INDEX=0; INDEX<${#DEPLOYMENT_UNIT_ARRAY[@]}; INDEX++)); do
     SHARED_IMAGE_FORMATS="?"
     SHARED_REGISTRY_SCOPE="?"
     if [[ -n "${SEGMENT_SHARED_BUILDS_DIR}" ]]; then
-        SHARED_BUILDS_DIR_FILE="${SEGMENT_SHARED_BUILDS_DIR}/${REGISTRY_DEPLOYMENT_UNIT}/shared_build.json"
-        if [[ -f "${SHARED_BUILDS_DIR_FILE}" ]]; then
-            getBuildReferenceParts "$(cat ${SHARED_BUILDS_DIR_FILE})"
-            SHARED_IMAGE_FORMATS="${BUILD_REFERENCE_FORMATS}"
-            SHARED_REGISTRY_SCOPE="${BUILD_REFERENCE_SCOPE}"
-        fi
+        # Support build.json and shared_build.json - build.json is preferred
+        for f in shared_build.json build.json; do
+            SHARED_BUILDS_DIR_FILE="${SEGMENT_SHARED_BUILDS_DIR}/${REGISTRY_DEPLOYMENT_UNIT}/$f"
+            if [[ -f "${SHARED_BUILDS_DIR_FILE}" ]]; then
+                getBuildReferenceParts "$(cat ${SHARED_BUILDS_DIR_FILE})"
+                [[ "${BUILD_REFERENCE_FORMATS}" != "?" ]] && SHARED_IMAGE_FORMATS="${BUILD_REFERENCE_FORMATS}"
+                [[ "${BUILD_REFERENCE_SCOPE}" != "?" ]] && SHARED_REGISTRY_SCOPE="${BUILD_REFERENCE_SCOPE}"
+            fi
+        done
     fi
 
     # Ensure appsettings directories exist


### PR DESCRIPTION
## Description
Check both build.json and shared_build.json for the scope and segment for a build.

## Motivation and Context
Both files can be present in the shared build tree. As scope/segment refer to the build itself, it seems more logical to put those in a build.json file in the shared tree, while if the unit is actually shared, then a reference in a shared_build.json suggests the correct
semantic.

## How Has This Been Tested?
Once built, will be tested with customer site.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
