### PR TITLE
fix: exit code for templates generation

### DIFF
--- a/execution/freemarker.sh
+++ b/execution/freemarker.sh
@@ -127,6 +127,6 @@ java -jar "${GENERATION_ENGINE_DIR}/bin/freemarker-wrapper-1.12.jar" \
     "${RAW_VARIABLES[@]}" \
     "${CMDB_MAPPINGS[@]}" \
     ${BASE_CMDB:+-b "${BASE_CMDB}"} \
-    ${LOGLEVEL:+--${LOGLEVEL}}
+    ${LOGLEVEL:+--${LOGLEVEL}} \
     "${CMDBS[@]}"
 RESULT=$?


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When an exception occurs in a template generation using the freemarker wrapper the process should exist with a non zero exit code so that other processes can report this failure.
## Description
<!--- Describe your changes in detail -->
A minor fix for  #77
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
