### PR TITLE
fix: shared formats/scope checks

### DIFF
--- a/automation/jenkins/aws/manageBuildReferences.sh
+++ b/automation/jenkins/aws/manageBuildReferences.sh
@@ -492,19 +492,19 @@ for ((INDEX=0; INDEX<${#DEPLOYMENT_UNIT_ARRAY[@]}; INDEX++)); do
                     (-f ${BUILD_FILE}) ]]; then
                 getBuildReferenceParts "$(cat ${BUILD_FILE})"
                 IMAGE_FORMATS="${BUILD_REFERENCE_FORMATS}"
-                # Format may be shared
-                [[ "${IMAGE_FORMATS}" == "?" ]] && IMAGE_FORMATS="${SHARED_IMAGE_FORMATS}"
-                IFS="${IMAGE_FORMAT_SEPARATORS}" read -ra CODE_IMAGE_FORMATS_ARRAY <<< "${IMAGE_FORMATS}"
             fi
+            # Format may be shared
+            [[ "${IMAGE_FORMATS}" == "?" ]] && IMAGE_FORMATS="${SHARED_IMAGE_FORMATS}"
+            IFS="${IMAGE_FORMAT_SEPARATORS}" read -ra CODE_IMAGE_FORMATS_ARRAY <<< "${IMAGE_FORMATS}"
 
             # If no scope explicitly defined, use the scope in the build reference if defined
             if [[ ("${REGISTRY_SCOPE}" == "?") &&
                     (-f ${BUILD_FILE}) ]]; then
                 getBuildReferenceParts "$(cat ${BUILD_FILE})"
-                # Scope may be shared
                 REGISTRY_SCOPE="${BUILD_REFERENCE_SCOPE}"
-                [[ "${REGISTRY_SCOPE}" == "?" ]] && REGISTRY_SCOPE="${SHARED_REGISTRY_SCOPE}"
             fi
+            # Scope may be shared
+            [[ "${REGISTRY_SCOPE}" == "?" ]] && REGISTRY_SCOPE="${SHARED_REGISTRY_SCOPE}"
 
             # If we don't know the image type, then there is a problem
             # Most likely it is the first time this unit has been mentioned and no format was


### PR DESCRIPTION
## Description
Checks for shared formats/scope should be performed even if no build file exists.

## Motivation and Context
This covers the creation of the build reference where the check is still needed for shared formats/scopes..

## How Has This Been Tested?
Customer deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
