### PR TITLE
refactor: switch COT to Hamlet

### DIFF
--- a/automation/jenkins/aws/integrator/setContext.sh
+++ b/automation/jenkins/aws/integrator/setContext.sh
@@ -64,9 +64,13 @@ done
 JOB_PATH=($(tr "/" " " <<< "${JOB_NAME}"))
 PARTS=()
 COT_PREFIX="cot-"
+HAMLET_PREFIX="hamlet-"
 for PART in ${JOB_PATH[@]}; do
     if [[ "${PART}" =~ ^${COT_PREFIX}* ]]; then
         PARTS+=("${PART#${COT_PREFIX}}")
+    fi
+    if [[ "${PART}" =~ ^${HAMLET_PREFIX}* ]]; then
+        PARTS+=("${PART#${HAMLET_PREFIX}}")
     fi
 done
 PARTS_COUNT="${#PARTS[@]}"

--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -564,6 +564,7 @@ function process_template_pass() {
 
   # Check for fatal strings in the output
   grep "COTFatal:" < "${template_result_file}" > "${template_result_file}-exceptionstrings"
+  grep "HamletFatal:" < "${template_result_file}" >> "${template_result_file}-exceptionstrings"
   if [[ -s "${template_result_file}-exceptionstrings"  ]]; then
     fatal "Exceptions occurred during template generation. Details follow...\n"
     case "$(fileExtension "${template_result_file}")" in
@@ -603,14 +604,20 @@ function process_template_pass() {
 
         existing_request_reference="$( grep "#--COT-RequestReference=" "${output_file}" )"
         [[ -n "${existing_request_reference}" ]] && sed_patterns+=("-e" "s/${existing_request_reference#"#--COT-RequestReference="}//g")
+        existing_request_reference="$( grep "#--Hamlet-RequestReference=" "${output_file}" )"
+        [[ -n "${existing_request_reference}" ]] && sed_patterns+=("-e" "s/${existing_request_reference#"#--Hamlet-RequestReference="}//g")
 
         existing_configuration_reference="$( grep "#--COT-ConfigurationReference=" "${output_file}" )"
         [[ -n "${existing_configuration_reference}" ]] && sed_patterns+=("-e" "s/${existing_configuration_reference#"#--COT-ConfigurationReference="}//g")
+        existing_configuration_reference="$( grep "#--Hamlet-ConfigurationReference=" "${output_file}" )"
+        [[ -n "${existing_configuration_reference}" ]] && sed_patterns+=("-e" "s/${existing_configuration_reference#"#--Hamlet-ConfigurationReference="}//g")
 
         if [[ "${TREAT_RUN_ID_DIFFERENCES_AS_SIGNIFICANT}" != "true" ]]; then
           sed_patterns+=("-e" "s/${run_id}//g")
           existing_run_id="$( grep "#--COT-RunId=" "${output_file}" )"
           [[ -n "${existing_run_id}" ]] && sed_patterns+=("-e" "s/${existing_run_id#"#--COT-RunId="}//g")
+          existing_run_id="$( grep "#--Hamlet-RunId=" "${output_file}" )"
+          [[ -n "${existing_run_id}" ]] && sed_patterns+=("-e" "s/${existing_run_id#"#--Hamlet-RunId="}//g")
         fi
 
         cat "${template_result_file}" | sed "${sed_patterns[@]}" > "${template_result_file}-new"
@@ -635,6 +642,8 @@ function process_template_pass() {
       # Detect any exceptions during generation
       jq -r ".COTMessages | select(.!=null) | .[] | select(.Severity == \"fatal\")" \
         < "${template_result_file}" > "${template_result_file}-exceptions"
+      jq -r ".HamletMessages | select(.!=null) | .[] | select(.Severity == \"fatal\")" \
+        < "${template_result_file}" >> "${template_result_file}-exceptions"
       if [[ -s "${template_result_file}-exceptions" ]]; then
         fatal "Exceptions occurred during template generation. Details follow...\n"
         cat "${template_result_file}-exceptions" >&2
@@ -713,7 +722,7 @@ function process_template() {
   case "${entrance}" in
 
     schema)
-      local cf_dir_default="${PRODUCT_STATE_DIR}/cot"
+      local cf_dir_default="${PRODUCT_STATE_DIR}/hamlet"
       ;;
 
     deployment)
@@ -749,7 +758,7 @@ function process_template() {
       ;;
 
     *)
-      local cf_dir_default="${PRODUCT_STATE_DIR}/cot/${ENVIRONMENT}/${SEGMENT}"
+      local cf_dir_default="${PRODUCT_STATE_DIR}/hamlet/${ENVIRONMENT}/${SEGMENT}"
       ;;
   esac
 

--- a/cli/runLambda.sh
+++ b/cli/runLambda.sh
@@ -8,7 +8,7 @@ trap '. ${GENERATION_BASE_DIR}/execution/cleanupContext.sh; exit ${RESULT:-1}' E
 #Defaults
 INCLUDE_LOG_TAIL_DEFAULT="true"
 
-tmpdir="$(getTempDir "cote_inf_XXX")"
+tmpdir="$(getTempDir "hamlete_inf_XXX")"
 
 function usage() {
     cat <<EOF
@@ -90,8 +90,8 @@ function main() {
     # Create build blueprint
     ${GENERATION_DIR}/createBuildblueprint.sh -u "${DEPLOYMENT_UNIT}" >/dev/null || return $?
 
-    COT_TEMPLATE_DIR="${PRODUCT_STATE_DIR}/cot/${ENVIRONMENT}/${SEGMENT}"
-    BUILD_BLUEPRINT="${COT_TEMPLATE_DIR}/build_blueprint-${DEPLOYMENT_UNIT}-config.json"
+    HAMLET_TEMPLATE_DIR="${PRODUCT_STATE_DIR}/hamlet/${ENVIRONMENT}/${SEGMENT}"
+    BUILD_BLUEPRINT="${HAMLET_TEMPLATE_DIR}/build_blueprint-${DEPLOYMENT_UNIT}-config.json"
 
     DEPLOYMENT_UNIT_TYPE="$(jq -r '.Type' < "${BUILD_BLUEPRINT}" )"
 


### PR DESCRIPTION
## Description
Add detection of messages in templates starting with "Hamlet".

## Motivation and Context
This is the first step in removing all usage of "COT" in favour of the current name. Once all usage has switched to "Hamlet", a second PR will be needed to remove the checking for "COT".

## How Has This Been Tested?
Local deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
Once this PR is commited, the following PRs can then be merged;

- [ ] https://github.com/hamlet-io/engine/pull/1413
- [ ] https://github.com/hamlet-io/engine-plugin-aws/pull/134
- [ ] https://github.com/hamlet-io/engine-plugin-azure/pull/205

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
