### PR TITLE
feat: make cache directory configurable

### DIFF
--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -126,6 +126,10 @@ function options() {
     # Set up the context
     . "${GENERATION_BASE_DIR}/execution/setContext.sh"
 
+    # Cache for asssembled components
+    CACHE_PATH="${ROOT_DIR//"/"/"_"}"
+    export GENERATION_CACHE_DIR="$( getCacheDir "${GENERATION_CACHE_DIR}" "${CACHE_PATH}" )"
+
     # Ensure we are in the right place
     case "${LEVEL}" in
       account)
@@ -140,7 +144,7 @@ function options() {
     esac
 
     # Assemble settings
-    export COMPOSITE_SETTINGS="${CACHE_DIR}/composite_settings.json"
+    export COMPOSITE_SETTINGS="${GENERATION_CACHE_DIR}/composite_settings.json"
     if [[ (("${GENERATION_USE_CACHE}" != "true") &&
             ("${GENERATION_USE_SETTINGS_CACHE}" != "true")) ||
         (! -f "${COMPOSITE_SETTINGS}") ]]; then
@@ -149,7 +153,7 @@ function options() {
     fi
 
     # Create the composite definitions
-    export COMPOSITE_DEFINITIONS="${CACHE_DIR}/composite_definitions.json"
+    export COMPOSITE_DEFINITIONS="${GENERATION_CACHE_DIR}/composite_definitions.json"
     if [[ (("${GENERATION_USE_CACHE}" != "true") &&
             ("${GENERATION_USE_DEFINITIONS_CACHE}" != "true")) ||
         (! -f "${COMPOSITE_DEFINITIONS}") ]]; then
@@ -157,7 +161,7 @@ function options() {
     fi
 
     # Create the composite stack outputs
-    export COMPOSITE_STACK_OUTPUTS="${CACHE_DIR}/composite_stack_outputs.json"
+    export COMPOSITE_STACK_OUTPUTS="${GENERATION_CACHE_DIR}/composite_stack_outputs.json"
     if [[ (("${GENERATION_USE_CACHE}" != "true") &&
             ("${GENERATION_USE_STACK_OUTPUTS_CACHE}" != "true")) ||
         (! -f "${COMPOSITE_STACK_OUTPUTS}") ]]; then
@@ -169,8 +173,8 @@ function options() {
   # Specific input control for mock input
   if [[ "${GENERATION_INPUT_SOURCE}" == "mock" ]]; then
 
-    export CACHE_DIR="${GENERATION_BASE_DIR}/.cache"
-    mkdir -p "${CACHE_DIR}"
+    # Cache for asssembled components
+    export GENERATION_CACHE_DIR="$( getCacheDir "${GENERATION_CACHE_DIR}" "" )"
 
     if [[ -z "${OUTPUT_DIR}" ]]; then
       fatalMandatory
@@ -182,7 +186,7 @@ function options() {
   # Add default composite fragments including end fragment
   if [[ (("${GENERATION_USE_CACHE}" != "true")  &&
       ("${GENERATION_USE_FRAGMENTS_CACHE}" != "true")) ||
-      (! -f "${CACHE_DIR}/composite_account.ftl") ]]; then
+      (! -f "${GENERATION_CACHE_DIR}/composite_account.ftl") ]]; then
 
       TEMPLATE_COMPOSITES=("account" "fragment")
       for composite in "${TEMPLATE_COMPOSITES[@]}"; do
@@ -228,11 +232,11 @@ function options() {
           declare -n composite_array="${composite}_array" ||
           eval "declare composite_array=(\"\${${composite}_array[@]}\")"
           debug "${composite^^}=${composite_array[*]}"
-          cat "${composite_array[@]}" > "${CACHE_DIR}/composite_${composite}.ftl"
+          cat "${composite_array[@]}" > "${GENERATION_CACHE_DIR}/composite_${composite}.ftl"
       done
 
       for composite in "segment" "solution" "application" "id" "name" "policy" "resource"; do
-          rm -rf "${CACHE_DIR}/composite_${composite}.ftl"
+          rm -rf "${GENERATION_CACHE_DIR}/composite_${composite}.ftl"
       done
   fi
 
@@ -480,7 +484,7 @@ function process_template_pass() {
   # Removal of drive letter (/?/) is specifically for MINGW
   # It shouldn't affect other platforms as it won't be matched
   for composite in "${template_composites[@]}"; do
-    composite_var="${CACHE_DIR}/composite_${composite,,}.ftl"
+    composite_var="${GENERATION_CACHE_DIR}/composite_${composite,,}.ftl"
     args+=("-r" "${composite,,}List=${composite_var#/?/}")
   done
 

--- a/execution/common.sh
+++ b/execution/common.sh
@@ -16,6 +16,9 @@ for dir in "${PLUGINDIRS[@]}"; do
     fi
 done
 
+# Set global default cache
+GENERATION_CACHE_DIR="${GENERATION_CACHE_DIR:-"${HOME}/.hamlet/cache"}"
+
 function getLogLevel() {
   checkLogLevel "${GENERATION_LOG_LEVEL}"
 }

--- a/execution/contextTree.sh
+++ b/execution/contextTree.sh
@@ -310,7 +310,7 @@ function assemble_composite_definitions() {
   jqMerge "${definitions_array[@]}" > "${tmp_file}"
 
   # Escape any freemarker markup
-  export COMPOSITE_DEFINITIONS="${CACHE_DIR}/composite_definitions.json"
+  export COMPOSITE_DEFINITIONS="${GENERATION_CACHE_DIR}/composite_definitions.json"
   sed 's/${/$\\{/g' < "${tmp_file}" > "${COMPOSITE_DEFINITIONS}"
 }
 
@@ -336,7 +336,7 @@ function assemble_composite_stack_outputs() {
 
   debug "STACK_OUTPUTS=${stack_array[*]}"
 
-  export COMPOSITE_STACK_OUTPUTS="${CACHE_DIR}/composite_stack_outputs.json"
+  export COMPOSITE_STACK_OUTPUTS="${GENERATION_CACHE_DIR}/composite_stack_outputs.json"
 
   getFilesAsJSON "${COMPOSITE_STACK_OUTPUTS}" "${stack_array[@]}"; return_status=$?
 

--- a/execution/setContext.sh
+++ b/execution/setContext.sh
@@ -48,10 +48,6 @@ if [[ "${GENERATION_NO_CMDB_CHECK}" != "true" ]]; then
         { fatal "CMDB cleanup failed."; exit 1; }
 fi
 
-# Ensure the cache directory exists
-export CACHE_DIR="${GENERATION_DATA_DIR}/cache"
-mkdir -p "${CACHE_DIR}"
-
 # Check if the current directory gives any clue to the context
 # Accommodate both pre cmdb v2.0.0 where segment/environment in the config tree
 # and post v2.0.0 where they are in the infrastructure tree
@@ -141,7 +137,7 @@ if [[ "${GENERATION_INPUT_SOURCE}" == "composite" ]]; then
     "${SEGMENT_SHARED_SOLUTIONS_DIR}" \
     "${PRODUCT_SHARED_SOLUTIONS_DIR}" )
 
-    export COMPOSITE_BLUEPRINT="${CACHE_DIR}/composite_blueprint.json"
+    export COMPOSITE_BLUEPRINT="${GENERATION_CACHE_DIR}/composite_blueprint.json"
     if [[ (("${GENERATION_USE_CACHE}" != "true") &&
             ("${GENERATION_USE_BLUEPRINT_CACHE}" != "true")) ||
         (! -f "${COMPOSITE_BLUEPRINT}") ]]; then
@@ -211,7 +207,7 @@ if [[ "${GENERATION_INPUT_SOURCE}" == "composite" ]]; then
 
     # Perform a few consistency checks
     [[ ! -s "${COMPOSITE_BLUEPRINT}" ]] && fatalCantProceed "The composite blueprint is empty. The likely cause of this is malformed JSON object in the Solution." && exit 1
-    
+
     [[ -z "${REGION}" ]] && fatalCantProceed "The region must be defined in the Product blueprint section." && exit 1
 
     BLUEPRINT_ACCOUNT=$(runJQ -r '.Account.Name | select(.!=null)' < ${COMPOSITE_BLUEPRINT})

--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -588,6 +588,25 @@ function getTempFile() {
     mktemp -t "${template}"
 }
 
+#-- Cache management
+
+function getCacheDir() {
+  local cache_root="$1"; shift
+  local cache_name="$1"; shift
+
+  if [[ -n "${cache_root}" ]]; then
+    mkdir -p "${cache_root}"
+  fi
+
+  if [[ -n "${cache_name}" ]]; then
+    cache_dir="${cache_root}/${cache_name}"
+    mkdir -p "${cache_dir}"
+    echo "${cache_dir}"
+  else
+    getTempDir "hamlet_cache_XXXXXX" "${cache_root}"
+  fi
+}
+
 # -- Cli file generation --
 function split_cli_file() {
   local cli_file="$1"; shift


### PR DESCRIPTION
## Description
Allows users to configure the cache directory used to assemble composite files during template generation 
This also moves the default cache location to `${HOME}/.hamlet/cache` to guarantee that the location can be written to, if this isn't the case then `GENERATION_CACHE_DIR` can also be set 

## Motivation and Context
Currently we use the `ROOT_DIR` of the CMDB that we are working in to define the location of the cache, with the introduction of the mock input source and the ability to create templates that do not depend on an underlying CMDB this directory is unreliable to use across all template passes 

So instead we need to have a writeable location that can be used to store the composite files. The users home drive feels like the safest location and allows for future usage if required

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
