### PR TITLE
fix: template cache creation directory

### DIFF
--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -120,15 +120,15 @@ function options() {
     return 1
   fi
 
+  # Cache for asssembled components
+  CACHE_PATH="${ROOT_DIR//"/"/"_"}"
+  export GENERATION_CACHE_DIR="$( getCacheDir "${GENERATION_CACHE_DIR}" "${CACHE_PATH}" )"
+
   # Input control for composite/CMDB input
   if [[ "${GENERATION_INPUT_SOURCE}" == "composite" ]]; then
 
     # Set up the context
     . "${GENERATION_BASE_DIR}/execution/setContext.sh"
-
-    # Cache for asssembled components
-    CACHE_PATH="${ROOT_DIR//"/"/"_"}"
-    export GENERATION_CACHE_DIR="$( getCacheDir "${GENERATION_CACHE_DIR}" "${CACHE_PATH}" )"
 
     # Ensure we are in the right place
     case "${LEVEL}" in
@@ -172,15 +172,11 @@ function options() {
 
   # Specific input control for mock input
   if [[ "${GENERATION_INPUT_SOURCE}" == "mock" ]]; then
-
-    # Cache for asssembled components
-    export GENERATION_CACHE_DIR="$( getCacheDir "${GENERATION_CACHE_DIR}" "" )"
-
     if [[ -z "${OUTPUT_DIR}" ]]; then
+      fatal "OUTPUT_DIR required for mock input source"
       fatalMandatory
       return 1
     fi
-
   fi
 
   # Add default composite fragments including end fragment


### PR DESCRIPTION
## Description
Minor fix on cache creation to ensure that the cache is available when its required. Uses the ROOT_DIR as the cache folder if its available

## Motivation and Context
The cache dir was being created after it was required in template generation

## How Has This Been Tested?
Tested locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
