### PR TITLE
Fix expo build

### DIFF
--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -127,15 +127,25 @@ function options() {
     . "${GENERATION_BASE_DIR}/execution/setContext.sh"
 
     # Ensure we are in the right place
-    case "${LEVEL}" in
-      account)
-        [[ ! ("${LEVEL}" =~ ${LOCATION}) ]] &&
-          fatalLocation "Current directory doesn't match requested level \"${LEVEL}\"." && return 1
+    case "${ENTRANCE}" in
+      buildblueprint)
         ;;
+      deployment)
+        case "${LEVEL}" in
+          account)
+            [[ ! ("${LEVEL}" =~ ${LOCATION}) ]] &&
+              fatalLocation "Current directory doesn't match requested level \"${LEVEL}\"." && return 1
+            ;;
 
-      solution|segment|application|blueprint|unitlist)
+          solution|segment|application)
+            [[ ! ("segment" =~ ${LOCATION}) ]] &&
+              fatalLocation "Current directory doesn't match requested level \"${LEVEL}\"." && return 1
+            ;;
+        esac
+        ;;
+      blueprint|unitlist)
         [[ ! ("segment" =~ ${LOCATION}) ]] &&
-          fatalLocation "Current directory doesn't match requested level \"${LEVEL}\"." && return 1
+          fatalLocation "Current directory doesn't match requested entrance \"${ENTRANCE}\"." && return 1
         ;;
     esac
 

--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -126,24 +126,15 @@ function options() {
     # Set up the context
     . "${GENERATION_BASE_DIR}/execution/setContext.sh"
 
-    # Ensure we are in the right place
-    case "${ENTRANCE}" in
-      deployment)
-        case "${LEVEL}" in
-          account)
-            [[ ! ("${LEVEL}" =~ ${LOCATION}) ]] &&
-              fatalLocation "Current directory doesn't match requested level \"${LEVEL}\"." && return 1
-            ;;
-
-          solution|segment|application)
-            [[ ! ("segment" =~ ${LOCATION}) ]] &&
-              fatalLocation "Current directory doesn't match requested level \"${LEVEL}\"." && return 1
-            ;;
-        esac
+    case "${LEVEL}" in
+      account)
+        [[ -z "${ACCOUNT_DIR}" ]] &&
+          fatalLocation "Could not find ACCOUNT_DIR directory for account: \"${ACCOUNT}\"" && return 1
         ;;
-      blueprint|unitlist)
-        [[ ! ("segment" =~ ${LOCATION}) ]] &&
-          fatalLocation "Current directory doesn't match requested entrance \"${ENTRANCE}\"." && return 1
+
+      *)
+        [[ -z "${SEGMENT_SOLUTIONS_DIR}" ]] &&
+          fatalLocation "Cound not find SEGMENT_SOLUTIONS_DIR directory for segment \"${SEGMENT}\"" && return 1
         ;;
     esac
 

--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -128,8 +128,6 @@ function options() {
 
     # Ensure we are in the right place
     case "${ENTRANCE}" in
-      buildblueprint)
-        ;;
       deployment)
         case "${LEVEL}" in
           account)

--- a/cli/runExpoAppPublish.sh
+++ b/cli/runExpoAppPublish.sh
@@ -329,12 +329,7 @@ function main() {
 
   # Create build blueprint
   info "Generating build blueprint..."
-  pushd "$(pwd)"
-  echo "Seg Dir: ${SEGMENT_SOLUTIONS_DIR}"
-  cd "${SEGMENT_SOLUTIONS_DIR}"
   "${GENERATION_DIR}/createBuildblueprint.sh" -l "${DEPLOYMENT_GROUP}" -u "${DEPLOYMENT_UNIT}" -o "${AUTOMATION_DATA_DIR}" >/dev/null || return $?
-  popd
-
   BUILD_BLUEPRINT="${AUTOMATION_DATA_DIR}/buildblueprint-${DEPLOYMENT_GROUP}-${DEPLOYMENT_UNIT}-config.json"
 
   # Make sure we are in the build source directory
@@ -591,6 +586,8 @@ function main() {
             get_configfile_property "${CONFIG_FILE}" "IOS_DIST_P12_PASSWORD" "${KMS_PREFIX}" "${AWS_REGION}"
 
             TURTLE_EXTRA_BUILD_ARGS="${TURTLE_EXTRA_BUILD_ARGS} --team-id ${IOS_DIST_APPLE_ID} --dist-p12-path ${IOS_DIST_P12_FILE} --provisioning-profile-path ${IOS_DIST_PROVISIONING_PROFILE}"
+
+            echo "Turtle params ${TURTLE_EXTRA_BUILD_ARGS}"
             ;;
         "*")
             echo "Unkown build format" && return 128

--- a/cli/runExpoAppPublish.sh
+++ b/cli/runExpoAppPublish.sh
@@ -585,9 +585,9 @@ function main() {
             get_configfile_property "${CONFIG_FILE}" "IOS_TESTFLIGHT_PASSWORD" "${KMS_PREFIX}" "${AWS_REGION}"
             get_configfile_property "${CONFIG_FILE}" "IOS_DIST_P12_PASSWORD" "${KMS_PREFIX}" "${AWS_REGION}"
 
+            # Turtle Specific overrides
             TURTLE_EXTRA_BUILD_ARGS="${TURTLE_EXTRA_BUILD_ARGS} --team-id ${IOS_DIST_APPLE_ID} --dist-p12-path ${IOS_DIST_P12_FILE} --provisioning-profile-path ${IOS_DIST_PROVISIONING_PROFILE}"
-
-            echo "Turtle params ${TURTLE_EXTRA_BUILD_ARGS}"
+            export EXPO_IOS_DIST_P12_PASSWORD="${IOS_DIST_P12_PASSWORD}"
             ;;
         "*")
             echo "Unkown build format" && return 128

--- a/cli/runExpoAppPublish.sh
+++ b/cli/runExpoAppPublish.sh
@@ -329,7 +329,11 @@ function main() {
 
   # Create build blueprint
   info "Generating build blueprint..."
+  pushd "$(pwd)"
+  cd "${SEGMENT_SOLUTIONS_DIR}"
   "${GENERATION_DIR}/createBuildblueprint.sh" -l "${DEPLOYMENT_GROUP}" -u "${DEPLOYMENT_UNIT}" -o "${AUTOMATION_DATA_DIR}" >/dev/null || return $?
+  popd
+
   BUILD_BLUEPRINT="${AUTOMATION_DATA_DIR}/buildblueprint-${DEPLOYMENT_GROUP}-${DEPLOYMENT_UNIT}-config.json"
 
   # Make sure we are in the build source directory

--- a/cli/runExpoAppPublish.sh
+++ b/cli/runExpoAppPublish.sh
@@ -330,6 +330,7 @@ function main() {
   # Create build blueprint
   info "Generating build blueprint..."
   pushd "$(pwd)"
+  echo "Seg Dir: ${SEGMENT_SOLUTIONS_DIR}"
   cd "${SEGMENT_SOLUTIONS_DIR}"
   "${GENERATION_DIR}/createBuildblueprint.sh" -l "${DEPLOYMENT_GROUP}" -u "${DEPLOYMENT_UNIT}" -o "${AUTOMATION_DATA_DIR}" >/dev/null || return $?
   popd


### PR DESCRIPTION
## Description
A collection of fixes to the expo build process 
- Allow for generation of templates even if you aren't in the SEGMENT dir instead we require that the SEGMENT_SOLUTION_DIR variable is defined. This achieves the same outcome but allows for the createTemplate command to be run anywhere
- Remove multi manfiest generation for turtle based expo builds as they are no longer supported and were not really used anyway 
- Add env var for turtle builds to provide the P12 IOS password

## Motivation and Context
Expo/turtle based IOS builds were failing

## How Has This Been Tested?
Tested on OSX build server 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
