### PR TITLE
refactor: separate function to get openapi definition

### DIFF
--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -238,6 +238,14 @@ function options() {
   return 0
 }
 
+function get_openapi_definition_filename() {
+  local name="$1"; shift
+  local accountId="$1"; shift
+  local region="$1"; shift
+
+  echo -n "${cf_dir}/defn-${name}-${accountId}-${region}-definition.json"
+}
+
 function get_openapi_definition_file() {
   local registry="$1"; shift
   local openapi_zip="$1"; shift
@@ -251,7 +259,7 @@ function get_openapi_definition_file() {
   local openapi_file_dir="$(getTopTempDir)"
 
   # Name definitions based on the component
-  local definition_file="${cf_dir}/defn-${name}-${accountId}-${region}-definition.json"
+  local definition_file=$( get_openapi_definition_filename "${name}" "${accountId}" "${region}" )
 
   local openapi_file="${openapi_file_dir}/${registry}-extended-base.json"
   local legacy_openapi_file="${openapi_file_dir}/${registry}-${region}-${accountNumber}.json"


### PR DESCRIPTION

## Description
Separate out the formatting of the definition file into its own function.

## Motivation and Context
Ensure consistency of filenames across uses.

## How Has This Been Tested?
Local deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
