### PR TITLE
feat: allow for overrides of outputdir in deployments

### DIFF
--- a/cli/manageDeployment.sh
+++ b/cli/manageDeployment.sh
@@ -29,6 +29,7 @@ function usage() {
   (o) -i (DEPLOYMENT_MONITOR=false)     initiates but does not monitor the deployment operation.
   (m) -l LEVEL                          is the deployment level - "account", "product", "segment", "solution", "application" or "multiple"
   (o) -m (DEPLOYMENT_INITIATE=false)    monitors but does not initiate the deployment operation.
+  (o) -o OUTPUT_DIR               is an override for the deployment output directory
   (o) -r REGION                         is the Azure location/region code for this deployment.
   (o) -s DEPLOYMENT_SCOPE               the deployment scope - "subscription" or "resourceGroup"
   (m) -u DEPLOYMENT_UNIT                is the deployment unit used to determine the deployment template.
@@ -52,7 +53,7 @@ EOF
 
 function options() {
   # Parse options
-  while getopts ":dg:hil:mqr:s:u:w::yz:" option; do
+  while getopts ":dg:hil:mo:qr:s:u:w::yz:" option; do
     case "${option}" in
       d) DEPLOYMENT_OPERATION=delete ;;
       g) RESOURCE_GROUP="${OPTARG}" ;;
@@ -60,6 +61,7 @@ function options() {
       i) DEPLOYMENT_MONITOR=false ;;
       l) LEVEL="${OPTARG}" ;;
       m) DEPLOYMENT_INITIATE=false ;;
+      o) OUTPUT_DIR="${OPTARG}" ;;
       q) QUIET_MODE="true" ;;
       r) REGION="${OPTARG}" ;;
       s) DEPLOYMENT_SCOPE="${OPTARG}" ;;
@@ -366,7 +368,7 @@ function main() {
   # by the epilogue script
   if [[ -s "${EPILOGUE}" ]]; then
     info "Processing epilogue script ..."
-    if [[ -z "${DRYRUN}" ]]; then 
+    if [[ -z "${DRYRUN}" ]]; then
       . "${EPILOGUE}" || return $?
     fi
   fi

--- a/cli/manageStack.sh
+++ b/cli/manageStack.sh
@@ -26,6 +26,7 @@ where
 (m) -l LEVEL                    is the stack level - "account", "product", "segment", "solution", "application" or "multiple"
 (o) -m (STACK_INITIATE=false)   monitors but does not initiate the stack operation
 (o) -n STACK_NAME               to override standard stack naming
+(o) -o OUTPUT_DIR               is an override for the deployment output directory
 (o) -q (QUIET_MODE=true)        minimise output generated
 (o) -r REGION                   is the AWS region identifier for the region in which the stack should be managed
 (m) -u DEPLOYMENT_UNIT          is the deployment unit used to determine the stack template
@@ -58,7 +59,7 @@ EOF
 
 function options() {
   # Parse options
-  while getopts ":dhil:mn:qr:u:w:yz:" option; do
+  while getopts ":dhil:mn:qr:t:u:w:yz:" option; do
     case "${option}" in
       d) STACK_OPERATION=delete ;;
       h) usage; return 1 ;;
@@ -66,6 +67,7 @@ function options() {
       l) LEVEL="${OPTARG}" ;;
       m) STACK_INITIATE=false ;;
       n) STACK_NAME="${OPTARG}" ;;
+      o) OUTPUT_DIR="${OPTARG}" ;;
       q) QUIET_MODE=true ;;
       r) REGION="${OPTARG}" ;;
       u) DEPLOYMENT_UNIT="${OPTARG}" ;;


### PR DESCRIPTION
## Description
Allows for overriding the output directory location for manageDeployment and manageStack 

## Motivation and Context
This is most likely a rare occurrence but the intention is to align the manageDeployment and manageStack commands with the createTemplate command which can specify a custom output directory 

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
