### PR TITLE
fix: include output dir in getopts

### DIFF
--- a/cli/manageStack.sh
+++ b/cli/manageStack.sh
@@ -59,7 +59,7 @@ EOF
 
 function options() {
   # Parse options
-  while getopts ":dhil:mn:qr:t:u:w:yz:" option; do
+  while getopts ":dhil:mn:o:qr:t:u:w:yz:" option; do
     case "${option}" in
       d) STACK_OPERATION=delete ;;
       h) usage; return 1 ;;


### PR DESCRIPTION
## Description
Minor fix to include the OUTPUT_DIR in the getopts definition

## Motivation and Context
It was included in documentation and case statement just not in the actual bit that uses it 

## How Has This Been Tested?
Tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
