### PR TITLE
refactor: remove cmdb tagging

### DIFF
--- a/automation/jenkins/aws/acceptRelease.sh
+++ b/automation/jenkins/aws/acceptRelease.sh
@@ -14,19 +14,4 @@ RESULT=$? && [[ "${RESULT}" -ne 0 ]] && exit
 
 # Tag the builds
 ${AUTOMATION_DIR}/manageBuildReferences.sh -a "${RELEASE_TAG}"
-RESULT=$? && [[ "${RESULT}" -ne 0 ]] && exit
-
-# Verify the build information
-if [[ "${RELEASE_MODE}" == "${RELEASE_MODE_ACCEPTANCE}" ]]; then
-
-    # Record acceptance of the config
-    save_product_config "${DETAIL_MESSAGE}" "${PRODUCT_CONFIG_REFERENCE}" "${RELEASE_MODE_TAG}"
-    RESULT=$? && [[ ${RESULT} -ne 0 ]] && exit
-
-    # Record acceptance of the infrastructure
-    save_product_infrastructure "${DETAIL_MESSAGE}" "${PRODUCT_INFRASTRUCTURE_REFERENCE}" "${RELEASE_MODE_TAG}"
-    RESULT=$? && [[ ${RESULT} -ne 0 ]] && exit
-fi
-
-# All good
-RESULT=0
+RESULT=$?

--- a/automation/jenkins/aws/deploy.sh
+++ b/automation/jenkins/aws/deploy.sh
@@ -5,19 +5,15 @@ trap 'exit 1' SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
 function main() {
-    if [[ "${SEGMENT}" == "default" ]]; then
-        TAG="deploy${AUTOMATION_JOB_IDENTIFIER}-${PRODUCT}-${ENVIRONMENT}"
-    else
-        TAG="deploy${AUTOMATION_JOB_IDENTIFIER}-${PRODUCT}-${ENVIRONMENT}-${SEGMENT}"
-    fi
-    # Create the templates
-    ${AUTOMATION_DIR}/manageUnits.sh -l "application" -a "${DEPLOYMENT_UNIT_LIST}" -r "${PRODUCT_CONFIG_COMMIT}" || return $?
+  # Add conventional commit details
+  DETAIL_MESSAGE="${DETAIL_MESSAGE}, cctype=deploy, ccdesc=${AUTOMATION_JOB_IDENTIFIER}"
+  save_context_property DETAIL_MESSAGE
 
-    # All ok so tag the config repo
-    save_product_config "${DETAIL_MESSAGE}" "${PRODUCT_CONFIG_REFERENCE}" "${TAG}" || return $?
+  # Create the templates
+  ${AUTOMATION_DIR}/manageUnits.sh -l "application" -a "${DEPLOYMENT_UNIT_LIST}" -r "${PRODUCT_CONFIG_COMMIT}" || return $?
 
-    # Commit the generated application templates
-    save_product_infrastructure "${DETAIL_MESSAGE}" "${PRODUCT_INFRASTRUCTURE_REFERENCE}" "${TAG}" || return $?
+  # Commit the generated application templates
+  save_product_infrastructure "${DETAIL_MESSAGE}" "${PRODUCT_INFRASTRUCTURE_REFERENCE}" || return $?
 }
 
 main "$@"

--- a/automation/jenkins/aws/deployRelease.sh
+++ b/automation/jenkins/aws/deployRelease.sh
@@ -5,18 +5,15 @@ trap 'exit 1' SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
 function main() {
+  # Add conventional commit and deploy/release tag to details
+  DETAIL_MESSAGE="deployment=${DEPLOYMENT_TAG}, release=${RELEASE_TAG}, ${DETAIL_MESSAGE}, cctype=deploy, ccdesc=${AUTOMATION_JOB_IDENTIFIER}"
+  save_context_property DETAIL_MESSAGE
+
   # Update the stacks
   ${AUTOMATION_DIR}/manageUnits.sh -l "application" -a "${DEPLOYMENT_UNIT_LIST}" || return $?
 
-  # Add release and deployment tags to details
-  DETAIL_MESSAGE="deployment=${DEPLOYMENT_TAG}, release=${RELEASE_TAG}, ${DETAIL_MESSAGE}"
-  save_context_property DETAIL_MESSAGE
-
-  # All ok so tag the config repo
-  save_product_config "${DETAIL_MESSAGE}" "${PRODUCT_CONFIG_REFERENCE}" "${DEPLOYMENT_TAG}" || return $?
-
   # Commit the generated application templates
-  save_product_infrastructure "${DETAIL_MESSAGE}" "${PRODUCT_INFRASTRUCTURE_REFERENCE}" "${DEPLOYMENT_TAG}" || return $?
+  save_product_infrastructure "${DETAIL_MESSAGE}" "${PRODUCT_INFRASTRUCTURE_REFERENCE}" || return $?
 }
 
 main "$@"

--- a/automation/jenkins/aws/manageEnvironment.sh
+++ b/automation/jenkins/aws/manageEnvironment.sh
@@ -5,19 +5,16 @@ trap 'exit 1' SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
 function main() {
-  if [[ "${SEGMENT}" == "default" ]]; then
-    TAG="env${AUTOMATION_JOB_IDENTIFIER}-${PRODUCT}-${ENVIRONMENT}"
-  else
-    TAG="env${AUTOMATION_JOB_IDENTIFIER}-${PRODUCT}-${ENVIRONMENT}-${SEGMENT}"
-  fi
+  # Add conventional commit details
+  DETAIL_MESSAGE="${DETAIL_MESSAGE}, cctype=manage, ccdesc=${AUTOMATION_JOB_IDENTIFIER}"
 
-  ${AUTOMATION_DIR}/manageUnits.sh -r "${TAG}" || return $?
+  ${AUTOMATION_DIR}/manageUnits.sh -r "${PRODUCT_CONFIG_COMMIT}" || return $?
 
-  # All ok so tag the config repo
-  save_product_config "${DETAIL_MESSAGE}" "${PRODUCT_CONFIG_REFERENCE}" "${TAG}" || return $?
-  
-  # Commit the generated application templates
-  save_product_infrastructure "${DETAIL_MESSAGE}" "${PRODUCT_INFRASTRUCTURE_REFERENCE}" "${TAG}" || return $?
+  # Commit the config repo
+  save_product_config "${DETAIL_MESSAGE}" "${PRODUCT_CONFIG_REFERENCE}" || return $?
+
+  # Commit the generated templates/stacks
+  save_product_infrastructure "${DETAIL_MESSAGE}" "${PRODUCT_INFRASTRUCTURE_REFERENCE}" || return $?
 }
 
 main "$@"

--- a/automation/jenkins/aws/manageRepo.sh
+++ b/automation/jenkins/aws/manageRepo.sh
@@ -116,7 +116,21 @@ function push() {
     if [[ -n "$(git status --porcelain)" ]]; then
         # Commit changes
         debug "Committing to the ${REPO_LOG_NAME} repo..."
-        git commit -m "${REPO_MESSAGE}"
+
+        # Break the message in name/value pairs
+        conventional_commit_base_body="$(format_conventional_commit_body "${REPO_MESSAGE}")"
+
+        # Separate the values based on the conventional commit format
+        conventional_commit_type="$( format_conventional_commit_body_summary "${conventional_commit_base_body}" "cctype" )"
+        conventional_commit_scope="$( format_conventional_commit_body_summary "${conventional_commit_base_body}" "account product environment segment" )"
+        conventional_commit_description="$( format_conventional_commit_body_summary "${conventional_commit_base_body}" "ccdesc" )"
+        conventional_commit_body="$( format_conventional_commit_body_subset "${conventional_commit_base_body}" "cctype ccdesc account product environment segment" )"
+
+        git commit -m "$(format_conventional_commit \
+            "${conventional_commit_type:-hamlet}" \
+            "${conventional_commit_scope}" \
+            "${conventional_commit_description:-automation}" \
+            "${conventional_commit_body}" )"
         RESULT=$? && [[ ${RESULT} -ne 0 ]] && fatal "Can't commit to the ${REPO_LOG_NAME} repo" && return 1
 
         REPO_PUSH_REQUIRED="true"

--- a/automation/jenkins/aws/updateBuildReferences.sh
+++ b/automation/jenkins/aws/updateBuildReferences.sh
@@ -8,8 +8,14 @@ trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 ${AUTOMATION_DIR}/manageBuildReferences.sh -u
 RESULT=$? && [[ ${RESULT} -ne 0 ]] && exit
 
+# Release mode info
+[[ -n "${RELEASE_MODE_TAG}" ]] && DETAIL_MESSAGE="${DETAIL_MESSAGE}, relmode=${RELEASE_MODE_TAG}"
+
+# Add conventional commit details
+DETAIL_MESSAGE="${DETAIL_MESSAGE}, cctype=updref, ccdesc=${AUTOMATION_JOB_IDENTIFIER}"
+
 # Save the results
-save_product_config "${DETAIL_MESSAGE}" "${PRODUCT_CONFIG_REFERENCE}" "${RELEASE_MODE_TAG}"
+save_product_config "${DETAIL_MESSAGE}" "${PRODUCT_CONFIG_REFERENCE}"
 RESULT=$? && [[ ${RESULT} -ne 0 ]] && exit
 
 if [[ (-n "${AUTODEPLOY+x}") &&


### PR DESCRIPTION
## Description
The tagging of the cmdb to reflect automation activities has not proven of use so this PR removes it from the various points where it was previously performed.

## Motivation and Context
Given that the same information as the tag is included in the cmdb commit message, the PR refactors it to be compliant with the
conventional commit standard, which makes it more usable. To minimise the change needed to achieve this, the commit message provided to manageRepo is assumed to be name/value pairs and key named values used to construct the conventional commit. Two extra named parameters are included to allow explicit control over the type and description.

## How Has This Been Tested?
It is difficult to test automation jobs without a Jenkins instance so the testing plan is to commit the changes, quickly test in key customers, and rapidly address any issues as they arise.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
