### PR TITLE
refactor: remove tagging of accounts cmdb

### DIFF
--- a/automation/constructTree.sh
+++ b/automation/constructTree.sh
@@ -289,6 +289,7 @@ if [[ !("${EXCLUDE_ACCOUNT_DIRECTORIES}" == "true") ]]; then
         fi
         mkdir -p $(filePath "${ACCOUNT_CONFIG_DIR}")
         mv "${BASE_DIR_TEMP}" "${ACCOUNT_CONFIG_DIR}"
+        save_context_property ACCOUNT_CONFIG_COMMIT "$(git -C "${ACCOUNT_CONFIG_DIR}" rev-parse HEAD)"
     fi
 
     ACCOUNT_INFRASTRUCTURE_DIR=$(findGen3AccountInfrastructureDir "${BASE_DIR}" "${ACCOUNT}")

--- a/automation/jenkins/aws/deploy.sh
+++ b/automation/jenkins/aws/deploy.sh
@@ -12,7 +12,8 @@ function main() {
   # Create the templates
   ${AUTOMATION_DIR}/manageUnits.sh -l "application" -a "${DEPLOYMENT_UNIT_LIST}" -r "${PRODUCT_CONFIG_COMMIT}" || return $?
 
-  # Commit the generated application templates
+  # Commit the generated application templates/stacks
+  # It is assumed no changes have been made to the config part of the cmdb
   save_product_infrastructure "${DETAIL_MESSAGE}" "${PRODUCT_INFRASTRUCTURE_REFERENCE}" || return $?
 }
 

--- a/automation/jenkins/aws/deployRelease.sh
+++ b/automation/jenkins/aws/deployRelease.sh
@@ -12,7 +12,8 @@ function main() {
   # Update the stacks
   ${AUTOMATION_DIR}/manageUnits.sh -l "application" -a "${DEPLOYMENT_UNIT_LIST}" || return $?
 
-  # Commit the generated application templates
+  # Commit the generated application templates/stacks
+  # It is assumed no changes have been made to the config part of the cmdb
   save_product_infrastructure "${DETAIL_MESSAGE}" "${PRODUCT_INFRASTRUCTURE_REFERENCE}" || return $?
 }
 

--- a/automation/jenkins/aws/manageAccount.sh
+++ b/automation/jenkins/aws/manageAccount.sh
@@ -5,21 +5,17 @@ trap 'exit 1' SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
 function main() {
-  [[ -n "${ACCOUNTS_LIST}" ]] &&
-    TAG="acc${AUTOMATION_JOB_IDENTIFIER}-${ACCOUNTS_LIST}" ||
-    TAG="acc${AUTOMATION_JOB_IDENTIFIER}-${ACCOUNT}"
+  # Add conventional commit details
+  DETAIL_MESSAGE="${DETAIL_MESSAGE}, cctype=manacc, ccdesc=${AUTOMATION_JOB_IDENTIFIER}"
 
-  ${AUTOMATION_DIR}/manageUnits.sh -r "${TAG}" || return $?
+  ${AUTOMATION_DIR}/manageUnits.sh -r "${ACCOUNT_CONFIG_COMMIT}" || return $?
 
+  # With the removal of tagging, this shouldn't be needed as no changes should be made to the config part of the cmdb
   # All ok so tag the config repo
-  save_repo "${ACCOUNT_DIR}" "account config" \
-    "${DETAIL_MESSAGE}" "${PRODUCT_CONFIG_REFERENCE}" "${TAG}" || return $?
-  
-  # Commit the generated application templates
-  save_repo "${ACCOUNT_INFRASTRUCTURE_DIR}" "account infrastructure" "${DETAIL_MESSAGE}" "${PRODUCT_INFRASTRUCTURE_REFERENCE}" "${TAG}" || return $?
+  # save_repo "${ACCOUNT_DIR}" "account config" "${DETAIL_MESSAGE}" "${PRODUCT_CONFIG_REFERENCE}" || return $?
+
+  # Commit the generated application templates/stacks
+  save_repo "${ACCOUNT_INFRASTRUCTURE_DIR}" "account infrastructure" "${DETAIL_MESSAGE}" "${PRODUCT_INFRASTRUCTURE_REFERENCE}" || return $?
 }
 
 main "$@"
-
-
-

--- a/automation/jenkins/aws/manageEnvironment.sh
+++ b/automation/jenkins/aws/manageEnvironment.sh
@@ -6,11 +6,13 @@ trap 'exit 1' SIGHUP SIGINT SIGTERM
 
 function main() {
   # Add conventional commit details
-  DETAIL_MESSAGE="${DETAIL_MESSAGE}, cctype=manage, ccdesc=${AUTOMATION_JOB_IDENTIFIER}"
+  DETAIL_MESSAGE="${DETAIL_MESSAGE}, cctype=manenv, ccdesc=${AUTOMATION_JOB_IDENTIFIER}"
 
   ${AUTOMATION_DIR}/manageUnits.sh -r "${PRODUCT_CONFIG_COMMIT}" || return $?
 
   # Commit the config repo
+  # Segment level units can result in updates the the operations tree which should be in the repo
+  # holding the state tree but just in case, check the repo holding the config as well
   save_product_config "${DETAIL_MESSAGE}" "${PRODUCT_CONFIG_REFERENCE}" || return $?
 
   # Commit the generated templates/stacks


### PR DESCRIPTION
## Description
In line with https://github.com/hamlet-io/executor-bash/pull/129, this change removes the tagging of changes made to the account cmdb.

Also add some further comments to automation jobs which are no longer committing/tagging the config part of the cmdb on the basis that they should only be affecting the infrastructure side, now that we are not tagging repos.

## Motivation and Context
Consistent with the approach to product configuration references, it introduces an ACCOUNT_CONFIG_COMMIT to use as the configuration reference value when updating accounts.

The commit messages will also start being formatted as conventional commits, with the first account id as the scope.

## How Has This Been Tested?
The bulk of the changes to the formatting of commits have already been tested with PR129. The simplest way to test this is to rerun a manageAccounts job once the changes are active within a customer site.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
