### PR TITLE
feat: plugin loading from contract

### DIFF
--- a/cli/setup.sh
+++ b/cli/setup.sh
@@ -5,22 +5,22 @@ trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 . "${GENERATION_BASE_DIR}/execution/common.sh"
 
 
-function update_provider_state() {
+function update_plugin_state() {
     local state="$1"; shift
-    local provider_id="$1"; shift
-    local provider_type="$1"; shift
-    local provider_ref="$1"; shift
+    local plugin_id="$1"; shift
+    local plugin_type="$1"; shift
+    local plugin_ref="$1"; shift
     local plugin_dir="$1"; shift
 
-    provider_ref="${provider_type}:${provider_ref}"
-    echo "${state}" | jq -r --arg id "${provider_id}" --arg type "${provider_type}" --arg ref "${provider_ref}" --arg plugin_dir "${plugin_dir}" \
-                          '.Providers[$id] = { type: $type, ref: $ref, plugin_dir: $plugin_dir }'
+    plugin_ref="${plugin_type}:${plugin_ref}"
+    echo "${state}" | jq -r --arg id "${plugin_id}" --arg type "${plugin_type}" --arg ref "${plugin_ref}" --arg plugin_dir "${plugin_dir}" \
+                          '.Plugins[$id] = { type: $type, ref: $ref, plugin_dir: $plugin_dir }'
 }
 
 function options() {
 
   # Parse options
-  while getopts ":hi:" option; do
+  while getopts ":hi:p:" option; do
       case "${option}" in
           i|p) TEMPLATE_ARGS="${TEMPLATE_ARGS} -${option} ${OPTARG}" ;;
           h) usage; return 1 ;;
@@ -63,20 +63,27 @@ function main() {
   options "$@" || return $?
 
   # Defaults
-  LOADER_DIR="${PROVIDER_CACHE_DIR}/_loader"
+  LOADER_DIR="${PLUGIN_CACHE_DIR}/_loader"
+  GIT_CLONE_DIR="${PLUGIN_CACHE_DIR}/_git"
+  PLUGIN_STATE_FILE="${PLUGIN_CACHE_DIR}/plugin-state.json"
+
   ${GENERATION_DIR}/createTemplate.sh -p "shared" -e loader -o "${LOADER_DIR}" ${TEMPLATE_ARGS} || return $?
 
-  # check for a provider contract
-  if [[ -f "${LOADER_DIR}/loader-providercontract.json" &&  -s "${LOADER_DIR}/loader-providercontract.json" ]]; then
+  # check for a plugin contract
+  if [[ -f "${LOADER_DIR}/loader-plugincontract.json" &&  -s "${LOADER_DIR}/loader-plugincontract.json" ]]; then
 
-    PROVIDER_CONTRACT="$( cat "${LOADER_DIR}/loader-providercontract.json" | jq '.' || return $? )"
+    PLUGIN_CONTRACT="$( cat "${LOADER_DIR}/loader-plugincontract.json" | jq '.' || return $? )"
 
-    # Find all steps for install_provider
-    readarray -t provider_sources_json <<< "$( echo "${PROVIDER_CONTRACT}" | jq -c -r '.Stages[].Steps[] | select(.Type == "install_provider" )')"
+    # Find all steps for install_plugin
+    readarray -t plugin_sources_json <<< "$( echo "${PLUGIN_CONTRACT}" | jq -c -r '.Stages[].Steps[] | select(.Type == "install_plugin" )')"
 
-    provider_state='{}'
+    if [[ -f "${PLUGIN_STATE_FILE}" ]]; then
+      plugin_state="$( cat "${PLUGIN_STATE_FILE}" | jq . )"
+    else
+      plugin_state='{}'
+    fi
 
-    # Add the shared provider state since that is fixed
+    # Add the shared plugin state since that is fixed
     if git -C "${GENERATION_ENGINE_DIR}" rev-parse --is-inside-work-tree &>/dev/null; then
       engine_ref="$(git -C "${GENERATION_ENGINE_DIR}" rev-parse --abbrev-ref HEAD)"
       engine_hash="$(git -C "${GENERATION_ENGINE_DIR}" show-ref --heads --tags --hash "${engine_ref}" )"
@@ -85,51 +92,27 @@ function main() {
       engine_remote="$( git -C "${GENERATION_ENGINE_DIR}" rev-parse --symbolic-full-name --abbrev-ref @{u} )"
       engine_remote_url="$( git -C "${GENERATION_ENGINE_DIR}" remote get-url "${engine_remote%%"/${engine_ref}"}" )"
 
-      provider_state="$( update_provider_state "${provider_state}" "_engine" "git" "${engine_short_hash}:${engine_remote_url}" "${GENERATION_ENGINE_DIR}" )"
+      plugin_state="$( update_plugin_state "${plugin_state}" "_engine" "git" "${engine_remote_url}:${engine_short_hash}" "${GENERATION_ENGINE_DIR}" )"
 
     else
-      provider_state="$( update_provider_state "${provider_state}" "_engine" "local" "${GENERATION_ENGINE_DIR}" "${GENERATION_ENGINE_DIR}" )"
+      plugin_state="$( update_plugin_state "${plugin_state}" "_engine" "local" "${GENERATION_ENGINE_DIR}" "${GENERATION_ENGINE_DIR}" )"
     fi
 
-    info "Loading providers from contract..."
+    info "Loading plugins from contract..."
 
-    for provider_source in "${provider_sources_json[@]}"; do
-      provider_instance_id="$( echo "${provider_source}" | jq -c -r '.Id' )"
-      provider_name="$( echo "${provider_source}" | jq -c -r '.Parameters.ProviderName' )"
-      source_type="$( echo "${provider_source}" | jq -c -r '.Parameters.Source')"
-      priority="$( echo "${provider_source}" | jq -c -r '.Parameters.Priority')"=
+    for plugin_source in "${plugin_sources_json[@]}"; do
+      plugin_instance_id="$( echo "${plugin_source}" | jq -c -r '.Id' )"
+      plugin_name="$( echo "${plugin_source}" | jq -c -r '.Parameters.Name' )"
+      source_type="$( echo "${plugin_source}" | jq -c -r '.Parameters.Source')"
 
-      provider_instance_dir="${PROVIDER_CACHE_DIR}/${provider_instance_id}"
-
-      info "[*] id:${provider_instance_id} - type:${source_type}"
-
-      # handle source type changes for a given id
-      existing_source="false"
-      existing_source_type="unkown"
-
-      if [[ -d "${provider_instance_dir}" ]]; then
-        existing_source="true"
-
-        if [[ "${existing_source_type}" == "unkown" && -L "${provider_instance_dir}" ]]; then
-          existing_source_type="local"
-        fi
-
-        if [[ "${existing_source_type}" == "unkown" ]]; then
-          if git -C "${provider_instance_dir}" rev-parse --is-inside-work-tree &>/dev/null; then
-            existing_source_type="git"
-          fi
-        fi
-
-        if [[ "${source_type}" != "${existing_source_type}" ]]; then
-          rm -rf "${provider_instance_dir}"
-        fi
-      fi
+      plugin_instance_dir="${PLUGIN_CACHE_DIR}/${plugin_name}"
+      info "[*] id:${plugin_instance_id} - name:${plugin_name}"
 
       case "${source_type}" in
         git)
-          git_url="$( echo "${provider_source}" | jq -c -r '.Parameters.git.Url | select (.!=null)' )"
-          git_ref="$( echo "${provider_source}" | jq -c -r '.Parameters.git.Ref | select (.!=null)' )"
-          git_plugin_dir="$( echo "${provider_source}" | jq -c -r '.Parameters.git.Directory | select (.!=null)' )"
+          git_url="$( echo "${plugin_source}" | jq -c -r '.Parameters.git.Url | select (.!=null)' )"
+          git_ref="$( echo "${plugin_source}" | jq -c -r '.Parameters.git.Ref | select (.!=null)' )"
+          git_plugin_dir="$( echo "${plugin_source}" | jq -c -r '.Parameters.git.Path | select (.!=null)' )"
 
           if [[ -z "${git_url}" && -z "${git_ref}" ]]; then
             error "Git Source missing details  url:${git_url} - ref:${git_ref}"
@@ -138,46 +121,55 @@ function main() {
 
           # repo auth
           git_auth_url="$( find_auth_for_git_url "${git_url}" )"
+          git_plugin_clone_dir="$( get_url_component "${git_url}" "host")_$(get_url_component "${git_url}" "path" )_${git_ref}"
+          git_plugin_clone_dir="${GIT_CLONE_DIR}/${git_plugin_clone_dir/"/"/""}"
 
           # Git validation
           git_ref="$( git check-ref-format --allow-onelevel --normalize "${git_ref}" || fatal "Invalid ref ${git_ref}" >&2 ; return $? )"
-          remote_ref="$( git ls-remote -q "${git_auth_url}" "${git_ref}" || fatal "Could not find remote provider - id: ${provider_instance_id} - Url: ${git_url} - Ref: ${git_ref}"; return $? )"
+          remote_ref="$( git ls-remote -q "${git_auth_url}" "${git_ref}" || fatal "Could not find remote plugin - id: ${plugin_instance_id} - Url: ${git_url} - Ref: ${git_ref}"; return $? )"
           remote_hash="$( echo "${remote_ref}" | cut -f 1 )"
 
           update_existing="false"
 
-          if [[ "${existing_source}" == "true" && "${existing_source_type}" == "git" ]]; then
+          if [[ -d "${git_plugin_clone_dir}" ]]; then
             update_existing="true"
 
-            if [[ "${git_auth_url}" != "$(git -C "${provider_instance_dir}" remote get-url origin)" ]]; then
-              rm -rf "${provider_instance_dir}"
+            if [[ "${git_auth_url}" != "$(git -C "${git_plugin_clone_dir}" remote get-url origin)" ]]; then
+              rm -rf "${git_plugin_clone_dir}"
               update_existing="false"
             fi
           fi
 
           if [[ "${update_existing}" == "true" ]]; then
-            current_hash="$(git -C "${provider_instance_dir}" show-ref --heads --tags --hash "${git_ref}" )"
+            current_hash="$(git -C "${git_plugin_clone_dir}" show-ref --heads --tags --hash "${git_ref}" )"
 
             if [[ "${current_hash}" != "${remote_hash}" ]]; then
-              git -C "${provider_instance_dir}" pull origin --update-shallow +"${git_ref}":"${git_ref}"
+              git -C "${git_plugin_clone_dir}" pull origin --update-shallow +"${git_ref}":"${git_ref}"
             fi
 
-            git -C "${provider_instance_dir}" checkout -q "${git_ref}"
+            git -C "${git_plugin_clone_dir}" checkout -q "${git_ref}"
 
           else
-            git clone --branch "${git_ref}" --depth 1 --single-branch "${git_auth_url}" "${provider_instance_dir}"
+            git clone --branch "${git_ref}" --depth 1 --single-branch "${git_auth_url}" "${git_plugin_clone_dir}"
           fi
 
+          local_path="${git_plugin_clone_dir}"
           if [[ -n "${git_plugin_dir}" ]]; then
-            provider_instance_dir="${provider_instance_dir}/${git_plugin_dir}"
+            local_path="${git_plugin_clone_dir}/${git_plugin_dir}"
           fi
 
-          short_hash="$(git -C "${provider_instance_dir}" rev-parse --short "${remote_hash}" )"
-          provider_state="$( update_provider_state "${provider_state}" "${provider_instance_id}" "${source_type}" "${short_hash}:${git_url}" "${provider_instance_dir}" )"
+          if [[ -L "${plugin_instance_dir}" ]]; then
+            ln -sfn "${local_path}" "${plugin_instance_dir}"
+          else
+            ln -s "${local_path}" "${plugin_instance_dir}"
+          fi
+
+          short_hash="$(git -C "${plugin_instance_dir}" rev-parse --short "${remote_hash}" )"
+          plugin_state="$( update_plugin_state "${plugin_state}" "${plugin_instance_id}" "${source_type}" "${git_url}:${short_hash}" "${plugin_instance_dir}" )"
           ;;
 
         local)
-          local_path="$( echo "${provider_source}" | jq -c -r '.Parameters.local.Path | select (.!=null)' )"
+          local_path="$( echo "${plugin_source}" | jq -c -r '.Parameters.local.Path | select (.!=null)' )"
 
           if [[ -z "${local_path}" ]]; then
             error "Local Source missing details  path:${local_path}"
@@ -185,23 +177,23 @@ function main() {
           fi
 
           if [[ -d "${local_path}" ]]; then
-            if [[ "${existing_source}" == "true" && "${existing_source_type}" == "local" ]]; then
-              ln -sfn "${local_path}" "${provider_instance_dir}"
+            if [[ -L "${plugin_instance_dir}" ]]; then
+              ln -sfn "${local_path}" "${plugin_instance_dir}"
             else
-              ln -s "${local_path}" "${provider_instance_dir}"
+              ln -s "${local_path}" "${plugin_instance_dir}"
             fi
 
-            provider_state="$( update_provider_state "${provider_state}" "${provider_instance_id}" "${source_type}" "${local_path}" "${provider_instance_dir}" )"
+            plugin_state="$( update_plugin_state "${plugin_state}" "${plugin_instance_id}" "${source_type}" "${local_path}" "${plugin_instance_dir}" )"
           else
-            warning "[!] id:${provider_instance_id} - type:${source_type} - not found - skipped"
-            rm -rf "${provider_instance_dir}"
+            warning "id:${plugin_instance_id} - type:${source_type} - not found - skipped"
+            rm -rf "${plugin_instance_dir}"
           fi
           ;;
 
       esac
     done
 
-    echo "${provider_state}" > "${PROVIDER_CACHE_DIR}/provider-state.json"
+    echo "${plugin_state}" > "${PLUGIN_CACHE_DIR}/plugin-state.json"
   fi
 
   RESULT=$?

--- a/cli/setup.sh
+++ b/cli/setup.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+
+[[ -n "${GENERATION_DEBUG}" ]] && set ${GENERATION_DEBUG}
+trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
+. "${GENERATION_BASE_DIR}/execution/common.sh"
+
+
+function update_provider_state() {
+    local state="$1"; shift
+    local provider_id="$1"; shift
+    local provider_type="$1"; shift
+    local provider_ref="$1"; shift
+    local plugin_dir="$1"; shift
+
+    provider_ref="${provider_type}:${provider_ref}"
+    echo "${state}" | jq -r --arg id "${provider_id}" --arg type "${provider_type}" --arg ref "${provider_ref}" --arg plugin_dir "${plugin_dir}" \
+                          '.Providers[$id] = { type: $type, ref: $ref, plugin_dir: $plugin_dir }'
+}
+
+function options() {
+
+  # Parse options
+  while getopts ":hi:" option; do
+      case "${option}" in
+          i|p) TEMPLATE_ARGS="${TEMPLATE_ARGS} -${option} ${OPTARG}" ;;
+          h) usage; return 1 ;;
+          \?) fatalOption; return 1 ;;
+      esac
+  done
+
+  return 0
+}
+
+function usage() {
+  cat <<EOF
+
+DESCRIPTION:
+  sets up your hamlet tenant ready for output generation
+
+USAGE:
+  $(basename $0)
+
+PARAMETERS:
+
+    -h                         shows this text
+(o) -i GENERATION_INPUT_SOURCE is the source of input data to use when generating the template - "composite", "mock"
+(o) -p GENERATION_PROVIDER     is an addittional provider which is forced to load from a dir in GENERATION_PLUGIN_DIRS
+
+
+  (m) mandatory, (o) optional, (d) deprecated
+
+DEFAULTS:
+
+
+NOTES:
+
+
+EOF
+}
+
+function main() {
+
+  options "$@" || return $?
+
+  # Defaults
+  LOADER_DIR="${PROVIDER_CACHE_DIR}/_loader"
+  ${GENERATION_DIR}/createTemplate.sh -p "shared" -e loader -o "${LOADER_DIR}" ${TEMPLATE_ARGS} || return $?
+
+  # check for a provider contract
+  if [[ -f "${LOADER_DIR}/loader-providercontract.json" &&  -s "${LOADER_DIR}/loader-providercontract.json" ]]; then
+
+    PROVIDER_CONTRACT="$( cat "${LOADER_DIR}/loader-providercontract.json" | jq '.' || return $? )"
+
+    # Find all steps for install_provider
+    readarray -t provider_sources_json <<< "$( echo "${PROVIDER_CONTRACT}" | jq -c -r '.Stages[].Steps[] | select(.Type == "install_provider" )')"
+
+    provider_state='{}'
+
+    # Add the shared provider state since that is fixed
+    if git -C "${GENERATION_ENGINE_DIR}" rev-parse --is-inside-work-tree &>/dev/null; then
+      engine_ref="$(git -C "${GENERATION_ENGINE_DIR}" rev-parse --abbrev-ref HEAD)"
+      engine_hash="$(git -C "${GENERATION_ENGINE_DIR}" show-ref --heads --tags --hash "${engine_ref}" )"
+      engine_short_hash="$(git -C "${GENERATION_ENGINE_DIR}" rev-parse --short "${engine_hash}" )"
+
+      engine_remote="$( git -C "${GENERATION_ENGINE_DIR}" rev-parse --symbolic-full-name --abbrev-ref @{u} )"
+      engine_remote_url="$( git -C "${GENERATION_ENGINE_DIR}" remote get-url "${engine_remote%%"/${engine_ref}"}" )"
+
+      provider_state="$( update_provider_state "${provider_state}" "_engine" "git" "${engine_short_hash}:${engine_remote_url}" "${GENERATION_ENGINE_DIR}" )"
+
+    else
+      provider_state="$( update_provider_state "${provider_state}" "_engine" "local" "${GENERATION_ENGINE_DIR}" "${GENERATION_ENGINE_DIR}" )"
+    fi
+
+    info "Loading providers from contract..."
+
+    for provider_source in "${provider_sources_json[@]}"; do
+      provider_instance_id="$( echo "${provider_source}" | jq -c -r '.Id' )"
+      provider_name="$( echo "${provider_source}" | jq -c -r '.Parameters.ProviderName' )"
+      source_type="$( echo "${provider_source}" | jq -c -r '.Parameters.Source')"
+      priority="$( echo "${provider_source}" | jq -c -r '.Parameters.Priority')"=
+
+      provider_instance_dir="${PROVIDER_CACHE_DIR}/${provider_instance_id}"
+
+      info "[*] id:${provider_instance_id} - type:${source_type}"
+
+      # handle source type changes for a given id
+      existing_source="false"
+      existing_source_type="unkown"
+
+      if [[ -d "${provider_instance_dir}" ]]; then
+        existing_source="true"
+
+        if [[ "${existing_source_type}" == "unkown" && -L "${provider_instance_dir}" ]]; then
+          existing_source_type="local"
+        fi
+
+        if [[ "${existing_source_type}" == "unkown" ]]; then
+          if git -C "${provider_instance_dir}" rev-parse --is-inside-work-tree &>/dev/null; then
+            existing_source_type="git"
+          fi
+        fi
+
+        if [[ "${source_type}" != "${existing_source_type}" ]]; then
+          rm -rf "${provider_instance_dir}"
+        fi
+      fi
+
+      case "${source_type}" in
+        git)
+          git_url="$( echo "${provider_source}" | jq -c -r '.Parameters.git.Url | select (.!=null)' )"
+          git_ref="$( echo "${provider_source}" | jq -c -r '.Parameters.git.Ref | select (.!=null)' )"
+          git_plugin_dir="$( echo "${provider_source}" | jq -c -r '.Parameters.git.Directory | select (.!=null)' )"
+
+          if [[ -z "${git_url}" && -z "${git_ref}" ]]; then
+            error "Git Source missing details  url:${git_url} - ref:${git_ref}"
+            continue
+          fi
+
+          # repo auth
+          git_auth_url="$( find_auth_for_git_url "${git_url}" )"
+
+          # Git validation
+          git_ref="$( git check-ref-format --allow-onelevel --normalize "${git_ref}" || fatal "Invalid ref ${git_ref}" >&2 ; return $? )"
+          remote_ref="$( git ls-remote -q "${git_auth_url}" "${git_ref}" || fatal "Could not find remote provider - id: ${provider_instance_id} - Url: ${git_url} - Ref: ${git_ref}"; return $? )"
+          remote_hash="$( echo "${remote_ref}" | cut -f 1 )"
+
+          update_existing="false"
+
+          if [[ "${existing_source}" == "true" && "${existing_source_type}" == "git" ]]; then
+            update_existing="true"
+
+            if [[ "${git_auth_url}" != "$(git -C "${provider_instance_dir}" remote get-url origin)" ]]; then
+              rm -rf "${provider_instance_dir}"
+              update_existing="false"
+            fi
+          fi
+
+          if [[ "${update_existing}" == "true" ]]; then
+            current_hash="$(git -C "${provider_instance_dir}" show-ref --heads --tags --hash "${git_ref}" )"
+
+            if [[ "${current_hash}" != "${remote_hash}" ]]; then
+              git -C "${provider_instance_dir}" pull origin --update-shallow +"${git_ref}":"${git_ref}"
+            fi
+
+            git -C "${provider_instance_dir}" checkout -q "${git_ref}"
+
+          else
+            git clone --branch "${git_ref}" --depth 1 --single-branch "${git_auth_url}" "${provider_instance_dir}"
+          fi
+
+          if [[ -n "${git_plugin_dir}" ]]; then
+            provider_instance_dir="${provider_instance_dir}/${git_plugin_dir}"
+          fi
+
+          short_hash="$(git -C "${provider_instance_dir}" rev-parse --short "${remote_hash}" )"
+          provider_state="$( update_provider_state "${provider_state}" "${provider_instance_id}" "${source_type}" "${short_hash}:${git_url}" "${provider_instance_dir}" )"
+          ;;
+
+        local)
+          local_path="$( echo "${provider_source}" | jq -c -r '.Parameters.local.Path | select (.!=null)' )"
+
+          if [[ -z "${local_path}" ]]; then
+            error "Local Source missing details  path:${local_path}"
+            continue
+          fi
+
+          if [[ -d "${local_path}" ]]; then
+            if [[ "${existing_source}" == "true" && "${existing_source_type}" == "local" ]]; then
+              ln -sfn "${local_path}" "${provider_instance_dir}"
+            else
+              ln -s "${local_path}" "${provider_instance_dir}"
+            fi
+
+            provider_state="$( update_provider_state "${provider_state}" "${provider_instance_id}" "${source_type}" "${local_path}" "${provider_instance_dir}" )"
+          else
+            warning "[!] id:${provider_instance_id} - type:${source_type} - not found - skipped"
+            rm -rf "${provider_instance_dir}"
+          fi
+          ;;
+
+      esac
+    done
+
+    echo "${provider_state}" > "${PROVIDER_CACHE_DIR}/provider-state.json"
+  fi
+
+  RESULT=$?
+  return "${RESULT}"
+}
+
+main "$@"

--- a/cli/setup.sh
+++ b/cli/setup.sh
@@ -110,9 +110,9 @@ function main() {
 
       case "${source_type}" in
         git)
-          git_url="$( echo "${plugin_source}" | jq -c -r '.Parameters.git.Url | select (.!=null)' )"
-          git_ref="$( echo "${plugin_source}" | jq -c -r '.Parameters.git.Ref | select (.!=null)' )"
-          git_plugin_dir="$( echo "${plugin_source}" | jq -c -r '.Parameters.git.Path | select (.!=null)' )"
+          git_url="$( echo "${plugin_source}" | jq -c -r '.Parameters["Source:git"].Url | select (.!=null)' )"
+          git_ref="$( echo "${plugin_source}" | jq -c -r '.Parameters["Source:git"].Ref | select (.!=null)' )"
+          git_plugin_dir="$( echo "${plugin_source}" | jq -c -r '.Parameters["Source:git"].Path | select (.!=null)' )"
 
           if [[ -z "${git_url}" && -z "${git_ref}" ]]; then
             error "Git Source missing details  url:${git_url} - ref:${git_ref}"
@@ -166,28 +166,6 @@ function main() {
 
           short_hash="$(git -C "${plugin_instance_dir}" rev-parse --short "${remote_hash}" )"
           plugin_state="$( update_plugin_state "${plugin_state}" "${plugin_instance_id}" "${source_type}" "${git_url}:${short_hash}" "${plugin_instance_dir}" )"
-          ;;
-
-        local)
-          local_path="$( echo "${plugin_source}" | jq -c -r '.Parameters.local.Path | select (.!=null)' )"
-
-          if [[ -z "${local_path}" ]]; then
-            error "Local Source missing details  path:${local_path}"
-            continue
-          fi
-
-          if [[ -d "${local_path}" ]]; then
-            if [[ -L "${plugin_instance_dir}" ]]; then
-              ln -sfn "${local_path}" "${plugin_instance_dir}"
-            else
-              ln -s "${local_path}" "${plugin_instance_dir}"
-            fi
-
-            plugin_state="$( update_plugin_state "${plugin_state}" "${plugin_instance_id}" "${source_type}" "${local_path}" "${plugin_instance_dir}" )"
-          else
-            warning "id:${plugin_instance_id} - type:${source_type} - not found - skipped"
-            rm -rf "${plugin_instance_dir}"
-          fi
           ;;
 
       esac

--- a/execution/common.sh
+++ b/execution/common.sh
@@ -17,8 +17,9 @@ for dir in "${PLUGINDIRS[@]}"; do
 done
 
 # Set global default cache
-GENERATION_CACHE_DIR="${GENERATION_CACHE_DIR:-"${HOME}/.hamlet/cache"}"
-PLUGIN_CACHE_DIR="${GENERATION_CACHE_DIR}/plugins"
+HAMLET_HOME_DIR="${HAMLET_HOME_DIR:-"${HOME}/.hamlet"}"
+GENERATION_CACHE_DIR="${HAMLET_HOME_DIR}/cache"
+PLUGIN_CACHE_DIR="${HAMLET_HOME_DIR}/plugins"
 
 function getLogLevel() {
   checkLogLevel "${GENERATION_LOG_LEVEL}"

--- a/execution/common.sh
+++ b/execution/common.sh
@@ -18,7 +18,7 @@ done
 
 # Set global default cache
 GENERATION_CACHE_DIR="${GENERATION_CACHE_DIR:-"${HOME}/.hamlet/cache"}"
-PROVIDER_CACHE_DIR="${GENERATION_CACHE_DIR}/providers"
+PLUGIN_CACHE_DIR="${GENERATION_CACHE_DIR}/plugins"
 
 function getLogLevel() {
   checkLogLevel "${GENERATION_LOG_LEVEL}"

--- a/execution/common.sh
+++ b/execution/common.sh
@@ -18,6 +18,7 @@ done
 
 # Set global default cache
 GENERATION_CACHE_DIR="${GENERATION_CACHE_DIR:-"${HOME}/.hamlet/cache"}"
+PROVIDER_CACHE_DIR="${GENERATION_CACHE_DIR}/providers"
 
 function getLogLevel() {
   checkLogLevel "${GENERATION_LOG_LEVEL}"

--- a/execution/setContext.sh
+++ b/execution/setContext.sh
@@ -130,10 +130,10 @@ findGen3Dirs "${GENERATION_DATA_DIR}" || exit
 # Build the composite solution ( aka blueprint)
 export GENERATION_INPUT_SOURCE="${GENERATION_INPUT_SOURCE:-"composite"}"
 
-if [[ "${GENERATION_INPUT_SOURCE}" == "composite" ]]; then
+# Cache for asssembled components
+export CACHE_DIR="$( getCacheDir "${GENERATION_CACHE_DIR}" )"
 
-    # Cache for asssembled components
-    export CACHE_DIR="$( getCacheDir "${GENERATION_CACHE_DIR}" )"
+if [[ "${GENERATION_INPUT_SOURCE}" == "composite" ]]; then
 
     blueprint_alternate_dirs=( \
     "${SEGMENT_SOLUTIONS_DIR}" \


### PR DESCRIPTION
## Description
executor implementation of https://github.com/hamlet-io/engine/pull/1469 which implements plugin sourcing and configuration from a CMDB via a contract. 

The engine generates a loader contract which outlines the plugins which need to be loaded. Using this information the executor establishes a plugin cache and retrieves the plugins from their sources.

The cache allows for the plugins to be shared across different districts when working locally

The process also generates a state file which can be used to determine the version of the different hamlet plugins that were used for a given pass. If the setup script isn't used to load the plugins then the existing
processes will continue working

Also adds some utility routines to handle urls for git auth

## Motivation and Context
The motivation behind this change is to handle version management for plugins as part of a CMDB. This ensures consistency across users working in the CMDB. It also provides visibility on where plugins are sourced and how they behave 

## How Has This Been Tested?
Tested locally 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] Requires https://github.com/hamlet-io/engine/pull/1469

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
