### PR TITLE
fix: git commit for builds

### DIFF
--- a/automation/setContext.sh
+++ b/automation/setContext.sh
@@ -557,6 +557,13 @@ function main() {
       CODE_PROVIDER_ARRAY+=("${PRODUCT_CODE_GIT_PROVIDER}")
   done
 
+  # For builds, need to capture any provided git commit even if no deployment units defined at this point
+  case ${AUTOMATION_PROVIDER} in
+      jenkins | azurepipelines)
+          [[ ( -n "${GIT_COMMIT}" ) && ( -z "${CODE_COMMIT_ARRAY[0]}" ) ]] && CODE_COMMIT_ARRAY[0]="${GIT_COMMIT}"
+          ;;
+  esac
+
   # Regenerate the deployment unit list in case the first code commit/tag or format was overriden
   UPDATED_UNITS_ARRAY=()
   for INDEX in $( seq 0 $((${#DEPLOYMENT_UNIT_ARRAY[@]}-1)) ); do


### PR DESCRIPTION
## Description
Ensure the git commit is captured in setContext.sh even if no deployment units are known initially.


## Motivation and Context
A previous change (https://github.com/hamlet-io/executor-bash/pull/101) to ensure the git commit was applied to all units if
desired did not account for the situation of builds, where the deployment unit to be used is not known until later in the process, but the git commit needs to be captured early.

This commit detects that condition and captures the git commit.

## How Has This Been Tested?
Modified affected build to test the change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
