### PR TITLE
feat(ec2): support for disabling scale in protection

### DIFF
--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -1263,7 +1263,7 @@ function remove_ec2_scaleinprotection() {
   protected_instances="$( aws --region "${region}" autoscaling describe-auto-scaling-groups --auto-scaling-group-names "${groupName}" --query 'AutoScalingGroups[*].Instances[?ProtectedFromScaleIn].InstanceId' --output text || return $? )"
   if [[ -n "${protected_instances}" ]]; then
     info "Disabling scale in protection to allow for scaling events"
-    aws --region "${region}" autoscaling set-instance-protection --auto-scaling-group-name "${groupName}" --no-protected-from-scale-in --instance-ids ${protected_instances} || return $?
+    aws --region "${region}" autoscaling set-instance-protection --auto-scaling-group-name "${groupName}" --no-protected-from-scale-in --instance-ids "${protected_instances}" || return $?
   fi
 }
 

--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -1256,6 +1256,17 @@ function update_ec2_autoscalegroup() {
   aws --region "${region}" autoscaling update-auto-scaling-group --auto-scaling-group-name "${groupName}" --cli-input-json "file://${configfile}" || return $?
 }
 
+function remove_ec2_scaleinprotection() {
+  local region="$1"; shift
+  local groupName="$1"; shift
+
+  protected_instances="$( aws --region "${region}" autoscaling describe-auto-scaling-groups --auto-scaling-group-names "${groupName}" --query 'AutoScalingGroups[*].Instances[?ProtectedFromScaleIn].InstanceId' --output text || return $? )"
+  if [[ -n "${protected_instances}" ]]; then
+    info "Disabling scale in protection to allow for scaling events"
+    aws --region "${region}" autoscaling set-instance-protection --auto-scaling-group-name "${groupName}" --no-protected-from-scale-in --instance-ids ${protected_instances} || return $?
+  fi
+}
+
 function manage_ec2_volume_encryption() {
   local region="$1"; shift
   local encryptionEnabled="$1"; shift


### PR DESCRIPTION
## Description
Adds an ec2 utility to remove scalein protection from any active instances in an autoscale group 

## Motivation and Context
See https://github.com/hamlet-io/engine-plugin-aws/pull/192 for motivation

## How Has This Been Tested?
Tested locally and on active deployments 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
