### PR TITLE
fix(ec2): allow for word splitting on instances

### DIFF
--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -1263,7 +1263,7 @@ function remove_ec2_scaleinprotection() {
   protected_instances="$( aws --region "${region}" autoscaling describe-auto-scaling-groups --auto-scaling-group-names "${groupName}" --query 'AutoScalingGroups[*].Instances[?ProtectedFromScaleIn].InstanceId' --output text || return $? )"
   if [[ -n "${protected_instances}" ]]; then
     info "Disabling scale in protection to allow for scaling events"
-    aws --region "${region}" autoscaling set-instance-protection --auto-scaling-group-name "${groupName}" --no-protected-from-scale-in --instance-ids "${protected_instances}" || return $?
+    aws --region "${region}" autoscaling set-instance-protection --auto-scaling-group-name "${groupName}" --no-protected-from-scale-in --instance-ids ${protected_instances} || return $?
   fi
 }
 


### PR DESCRIPTION
## Description
reverts the change added in https://github.com/hamlet-io/executor-bash/pull/136/commits/569a5f07e7e49bedbc85083fb5dc8fcb15c942c7 to allow for a list of space separated values to be provided to the aws cli for scale in protection

## Motivation and Context
When providing a list of values to the aws cli it requires the values as space separated values ( https://docs.aws.amazon.com/cli/latest/reference/autoscaling/set-instance-protection.html ) 
the output from the command that we retrieve the values from returns a space separated list so we need to allow for word splitting when providing the value to the aws cli.

## How Has This Been Tested?
Tested locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
