### PR TITLE
fix: support empy engine fragments

### DIFF
--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -214,8 +214,10 @@ function options() {
 
         # Legacy fragments
         for fragment in ${GENERATION_ENGINE_DIR}/legacy/${composite}/${composite}_*.ftl; do
-            $(inArray "${composite}_array" $(fileName "${fragment}")) && continue
-            addToArray "${composite}_array" "${fragment}"
+            if [[ -f "${fragment}" ]]; then
+              $(inArray "${composite}_array" $(fileName "${fragment}")) && continue
+              addToArray "${composite}_array" "${fragment}"
+            fi
         done
 
         # Legacy end fragments


### PR DESCRIPTION
## Description
A minor fix to allow for fragments to to be empty in the hamlet engine.


## Motivation and Context
This is required to support our migration to extensions which no longer
need to be assembled into a single template

## How Has This Been Tested?
Tested locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
