### PR TITLE
feat: account deployment unit region override

### DIFF
--- a/execution/setContext.sh
+++ b/execution/setContext.sh
@@ -196,6 +196,9 @@ if [[ "${GENERATION_INPUT_SOURCE}" == "composite" ]]; then
     # This to support legacy configuration
     export PROVIDERID=${PROVIDERID:-$(runJQ -r '.Account.AWSId | select(.!=null)' < ${COMPOSITE_BLUEPRINT})}
     export PROVIDERID=${PROVIDERID:-$(runJQ -r '.Account.AzureId | select(.!=null)' < ${COMPOSITE_BLUEPRINT})}
+    export ACCOUNT_DEPLOYMENTUNIT_REGION=${ACCOUNT_DEPLOYMENTUNIT_REGION:-$(runJQ --arg du ${DEPLOYMENT_UNIT} -r '.Account[$du].Region | select(.!=null)' <${COMPOSITE_BLUEPRINT} )}
+    export ACCOUNT_REGION=${ACCOUNT_REGION:-${ACCOUNT_DEPLOYMENTUNIT_REGION}}
+    export DEPLOYMENTUNIT_REGION=${DEPLOYMENTUNIT_REGION:-${ACCOUNT_DEPLOYMENTUNIT_REGION}}
     export ACCOUNT_REGION=${ACCOUNT_REGION:-$(runJQ -r '.Account.Region | select(.!=null)' < ${COMPOSITE_BLUEPRINT})}
     export PID=${PID:-$(runJQ -r '.Product.Id | select(.!="Product") | select(.!=null)' < ${COMPOSITE_BLUEPRINT})}
     export PRODUCT_REGION=${PRODUCT_REGION:-$(runJQ -r '.Product.Region | select(.!=null)' < ${COMPOSITE_BLUEPRINT})}
@@ -266,7 +269,7 @@ if [[ ((-z "${AWS_ACCESS_KEY_ID}") || (-z "${AWS_SECRET_ACCESS_KEY}")) ]]; then
     fi
     if [[ $ACCOUNT_PROVIDER == 'aws' ]]; then
         aws configure list --profile "${PROVIDERID}" > $(getTempFile "awsid_profile_status_XXXXXX.txt") 2>&1
-        if [[ $? -eq 0 ]]; then 
+        if [[ $? -eq 0 ]]; then
             export AWS_DEFAULT_PROFILE="${PROVIDERID}"
         fi
     fi

--- a/execution/setStackContext.sh
+++ b/execution/setStackContext.sh
@@ -188,7 +188,7 @@ if [[ ! -f "${CF_DIR}/${TEMPLATE}" ]]; then
 fi
 
 # Permit renaming of stack files without affecting existing stack status
-if [[ -f “${CF_DIR}/${STACK}” ]]; then
+if [[ -f "${CF_DIR}/${STACK}" ]]; then
     case ${ACCOUNT_PROVIDER} in
         azure)
             STACK_NAME=$(jq -r ".properties.outputs.resourceGroup.value" <  "${CF_DIR}/${STACK}")


### PR DESCRIPTION
## Description
Support the ability to override the region an account level unit is deployed into in the same manner as is currently supported for products.

Also correct use of unicode quotes by replacing with ASCII equivalent.

## Motivation and Context
This has been introduced to support the ability to create account level SES configuration for receiving emails in the regions in which it is supported.

## How Has This Been Tested?
Local template generation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
