### PR TITLE
fix: correct var for source build ref

### DIFF
--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -2902,7 +2902,7 @@ function get_url_image_to_registry() {
 
   popTempDir
 
-  update_build_reference_from_image "${product}" "${environment}" "${segment}" "${build_unit}" "${build_reference}" "${image_format}" "${source}"
+  update_build_reference_from_image "${product}" "${environment}" "${segment}" "${build_unit}" "${build_reference}" "${image_format}" "${source_url}"
 
   info "Uploading image to registry..."
   if [[ -n "${build_reference}" && -f "${local_dir}/${registry_file_name}" ]]; then


### PR DESCRIPTION
## Description
Minor fix to the Url image source function to use the correct variable for the build ref source 

## Motivation and Context
Allows you to see where an artefact came from in a URL based image source

## How Has This Been Tested?
Tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
