### PR TITLE
Refactor createTemplate logging

### DIFF
--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -296,7 +296,7 @@ function get_openapi_definition_file() {
   [[ -n "${openapi_definition}" ]] ||
       { fatal "Unable to locate ${registry} file in ${openapi_zip}"; popTempDir; return 1; }
 
-  info "Saving ${openapi_definition} to ${definition_file} ..."
+  info " ~ saving ${openapi_definition} to ${definition_file}"
 
   # Index via id to allow definitions to be combined into single composite
   addJSONAncestorObjects "${openapi_definition}" "${id}" > "${openapi_file_dir}/definition.json" ||
@@ -585,7 +585,7 @@ function process_template_pass() {
     # TODO(mfl): remove this check once all customers on cmdb >=2.0.1, as
     # cleanup is done once all passes have been processed in this case
     if [[ (-f "${output_file}") && ("${deployment_unit_state_subdirectories}" == "false") ]]; then
-      info " * removing existing ${file_description} file ${output_file}"
+      info " ~ removing existing ${file_description} file ${output_file}"
       rm "${output_file}"
     fi
 
@@ -661,7 +661,7 @@ function process_template_pass() {
       fi
 
       if [[ "${pass}" == "pregeneration" ]]; then
-        info "Processing pregeneration script ..."
+        info " ~ processing pregeneration script"
         [[ "${differences_detected}" == "true" ]] &&
           . "${result_file}" ||
           . "${output_file}"
@@ -715,7 +715,7 @@ function process_template_pass() {
         cat "${output_file}" | jq --indent 1 "${jq_pattern}" | sed "${sed_patterns[@]}" > "${template_result_file}-existing"
 
         diff "${template_result_file}-existing" "${template_result_file}-new" > "${template_result_file}-difference" &&
-          info " ~ no change in ${file_description} detected " ||
+          info " ~ no change in ${file_description} detected" ||
           differences_detected="true"
       fi
       ;;
@@ -989,7 +989,7 @@ function process_template() {
     fi
 
   else
-    info "No differences detected."
+    info " ~ no differences detected"
   fi
 
   return 0

--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -579,7 +579,7 @@ function process_template_pass() {
 
   # Ignore whitespace only files
   if [[ $(tr -d " \t\n\r\f" < "${template_result_file}" | wc -m) -eq 0 ]]; then
-    info " ~ ignoring emtpy ${file_description}"
+    info " ~ ignoring empty ${file_description}"
 
     # Remove any previous version
     # TODO(mfl): remove this check once all customers on cmdb >=2.0.1, as

--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -546,7 +546,7 @@ function process_template_pass() {
   [[ -n "${pass_deployment_unit_subset[${pass}]}" ]] && args+=("-v" "deploymentUnitSubset=${pass_deployment_unit_subset[${pass}]}")
 
   local file_description="${pass_description[${pass}]}"
-  info "Generating ${file_description} file ...\n"
+  info " - ${file_description}"
 
   [[ "${pass_alternative}" == "primary" ]] && pass_alternative=""
   pass_alternative_prefix=""
@@ -579,13 +579,13 @@ function process_template_pass() {
 
   # Ignore whitespace only files
   if [[ $(tr -d " \t\n\r\f" < "${template_result_file}" | wc -m) -eq 0 ]]; then
-    info "Ignoring empty ${file_description} file ...\n"
+    info " ~ ignoring emtpy ${file_description}"
 
     # Remove any previous version
     # TODO(mfl): remove this check once all customers on cmdb >=2.0.1, as
     # cleanup is done once all passes have been processed in this case
     if [[ (-f "${output_file}") && ("${deployment_unit_state_subdirectories}" == "false") ]]; then
-      info "... removing existing ${file_description} file ${output_file} ...\n"
+      info " * removing existing ${file_description} file ${output_file}"
       rm "${output_file}"
     fi
 
@@ -655,7 +655,7 @@ function process_template_pass() {
         cat "${output_file}" | sed "${sed_patterns[@]}" > "${template_result_file}-existing"
 
         diff "${template_result_file}-existing" "${template_result_file}-new" > "${template_result_file}-difference" &&
-          info "No change in ${file_description} detected ...\n" ||
+          info " ~ no change in ${file_description} detected" ||
           differences_detected="true"
 
       fi
@@ -715,7 +715,7 @@ function process_template_pass() {
         cat "${output_file}" | jq --indent 1 "${jq_pattern}" | sed "${sed_patterns[@]}" > "${template_result_file}-existing"
 
         diff "${template_result_file}-existing" "${template_result_file}-new" > "${template_result_file}-difference" &&
-          info "No change in ${file_description} detected ...\n" ||
+          info " ~ no change in ${file_description} detected " ||
           differences_detected="true"
       fi
       ;;
@@ -848,6 +848,8 @@ function process_template() {
   local results_dir="${tmp_dir}/results"
   mkdir -p "${results_dir}"
 
+  info "Generating outputs:"
+
   # First see if a generation contract can be generated
   process_template_pass \
       "${entrance}" \
@@ -894,7 +896,7 @@ function process_template() {
     0 | 255)
       # Use the contract to control further processing
       local generation_contract="${results_dir}/${results_list[0]}"
-      info "Generating documents from generation contract ${generation_contract}"
+      debug "Generating documents from generation contract ${generation_contract}"
       willLog "debug" && cat ${generation_contract}
 
       local task_list_file="$( getTempFile "XXXXXX" "${tmp_dir}" )"
@@ -957,10 +959,10 @@ function process_template() {
   # Copy the set of result file if necessary
   if [[ "${differences_detected}" == "true" ]]; then
 
-    info "Differences detected ..."
+    info "Differences detected:"
 
     for f in "${results_list[@]}"; do
-      info "... updating ${f} ..."
+      info " - updating ${f}"
       cp "${results_dir}/${f}" "${cf_dir}/${f}"
     done
 
@@ -975,12 +977,12 @@ function process_template() {
 
         for e in "${existing_files[@]}"; do
           local existing_filename="$(fileName "${e}")"
-          debug "... checking file ${existing_filename} ..."
+          debug " - checking file ${existing_filename}"
           # If generated, then ignore
           $(inArray "results_list" "${existing_filename}") && continue
 
           # Wasn't generated so remove
-          info "... removing ${existing_filename} ..."
+          info " - removing ${existing_filename}"
           rm  -f "${cf_dir}/${existing_filename}"
         done
       fi


### PR DESCRIPTION
## Description
Refactor the createTemplate logging to remove new lines and to try and make the output more concise 

Difference 

**Existing** 
```
${GENERATION_DIR}/createTemplate.sh -l solution -u door-cdn 
(Info) Generating generationcontract file ...

(Info) No change in generationcontract detected ...

(Info) Generating documents from generation contract /tmp/cot_NsoXDB/create_template_1YNPwd/create_template_MvD7x1/results/soln-door-cdn-mswdev02-ap-southeast-2-generation-contract.json
(Info) Generating prologue file ...

(Info) Ignoring empty prologue file ...

(Info) Generating template file ...

(Info) No change in template detected ...

(Info) Generating epilogue file ...

(Info) No change in epilogue detected ...

(Info) Generating cli file ...

(Info) Ignoring empty cli file ...

(Info) No differences detected.
```

**Updated**
```
${GENERATION_DIR}/createTemplate.sh -l solution -u door-cdn 
(Info) Generating outputs:
(Info)  - generationcontract
(Info)  ~ no change in generationcontract detected
(Info)  - prologue
(Info)  ~ ignoring emtpy prologue
(Info)  - template
(Info)  ~ no change in template detected
(Info)  - epilogue
(Info)  ~ no change in epilogue detected
(Info)  - cli
(Info)  ~ ignoring emtpy cli
(Info)  ~ no differences detected
```

## Motivation and Context
The createTemplate output is seen a lot throughout hamlet day to day activities so having a clean output is important for understanding and reducing noise in CI/CD pipelines

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
