### PR TITLE
refactor: handle missing plugin in setup

### DIFF
--- a/cli/setup.sh
+++ b/cli/setup.sh
@@ -158,6 +158,11 @@ function main() {
             local_path="${git_plugin_clone_dir}/${git_plugin_dir}"
           fi
 
+          if [[ ! -d "${local_path}" ]]; then
+            error "could not find plugin dir ${git_plugin_dir} in plugin repo ${git_url} - skipping plugin state update"
+            continue
+          fi
+
           if [[ -L "${plugin_instance_dir}" ]]; then
             ln -sfn "${local_path}" "${plugin_instance_dir}"
           else


### PR DESCRIPTION
## Description

Adds a check to see if the plugin folder with the a cloned repo exists as part of setup

## Motivation and Context

This provides users with information about why their plugin might not be loading properly and also allows for pipeline state to still be populated when one plugin is missing. Since we check for the plugin loading during the engine we handle the missing plugin at that point 

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
