### PR TITLE
feat(createTemplate): schemacontract outputs

### DIFF
--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -348,7 +348,7 @@ function process_template_pass() {
   local template_composites=()
 
   # Define the possible passes
-  local pass_list=("plugincontract" "managementcontract" "generationcontract" "testcase" "pregeneration" "prologue" "template" "epilogue" "cli" "parameters" "config" "schema")
+  local pass_list=("plugincontract" "managementcontract" "generationcontract" "testcase" "pregeneration" "prologue" "template" "epilogue" "cli" "parameters" "config" "schema" "schemacontract")
 
   # Initialise the components of the pass filenames
   declare -A pass_entrance_prefix
@@ -382,38 +382,9 @@ function process_template_pass() {
   template_composites+=("FRAGMENT" )
 
   case "${entrance}" in
-    unitlist)
-      # Blueprint applies across accounts and regions
-      for p in "${pass_list[@]}"; do
-        pass_account_prefix["${p}"]=""
-        pass_region_prefix["${p}"]=""
-      done
-      ;;
 
-    blueprint)
-      # Blueprint applies across accounts and regions
-      for p in "${pass_list[@]}"; do
-        pass_account_prefix["${p}"]=""
-        pass_region_prefix["${p}"]=""
-      done
-      ;;
-
-    buildblueprint)
-      # Blueprint applies across accounts and regions
-      for p in "${pass_list[@]}"; do
-        pass_account_prefix["${p}"]=""
-        pass_region_prefix["${p}"]=""
-      done
-      ;;
-
-    schema)
-      for p in "${pass_list[@]}"; do
-        pass_account_prefix["${p}"]=""
-        pass_region_prefix["${p}"]=""
-      done
-      ;;
-
-    loader)
+    # Outputs which don't belong to a deployment don't require region or account prefixes
+    unitlist|blueprint|buildblueprint|schema|loader|schemacontract)
       for p in "${pass_list[@]}"; do
         pass_account_prefix["${p}"]=""
         pass_region_prefix["${p}"]=""


### PR DESCRIPTION
## Description

Adds support for the schemacontract output handling in createTemplate. 

## Motivation and Context

By default we still allow entrance outputs to pass through the processing which by default sets a collection of file prefixes. The region and account are applicable for outputs generated outside of deployments so they should not be included in file name output

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
