### PR TITLE
fix(expo): control code sign id for ios

### DIFF
--- a/cli/runExpoAppPublish.sh
+++ b/cli/runExpoAppPublish.sh
@@ -78,7 +78,7 @@ DEFAULT_KMS_PREFIX="base64:"
 
 DEFAULT_DEPLOYMENT_GROUP="application"
 
-DEFAULT_IOS_CODESIGN_IDENTITY="iPhone Distribution"
+DEFAULT_IOS_DIST_CODESIGN_IDENTITY="iPhone Distribution"
 
 tmpdir="$(getTempDir "cote_inf_XXX")"
 
@@ -288,7 +288,7 @@ function options() {
     BUILD_LOGS="${BUILD_LOGS:-${DEFAULT_BUILD_LOGS}}"
     KMS_PREFIX="${KMS_PREFIX:-${DEFAULT_KMS_PREFIX}}"
     DEPLOYMENT_GROUP="${DEPLOYMENT_GROUP:-${DEFAULT_DEPLOYMENT_GROUP}}"
-    IOS_CODESIGN_IDENTITY="${IOS_CODESIGN_IDENTITY:-${DEFAULT_IOS_CODESIGN_IDENTITY}}"
+
 }
 
 
@@ -543,6 +543,9 @@ function main() {
             get_configfile_property "${CONFIG_FILE}" "IOS_TESTFLIGHT_USERNAME" "${KMS_PREFIX}" "${AWS_REGION}"
             get_configfile_property "${CONFIG_FILE}" "IOS_TESTFLIGHT_PASSWORD" "${KMS_PREFIX}" "${AWS_REGION}"
             get_configfile_property "${CONFIG_FILE}" "IOS_DIST_P12_PASSWORD" "${KMS_PREFIX}" "${AWS_REGION}"
+            get_configfile_property "${CONFIG_FILE}" "IOS_DIST_CODESIGN_IDENTITY" "${KMS_PREFIX}" "${AWS_REGION}"
+
+            IOS_DIST_CODESIGN_IDENTITY="${IOS_DIST_CODESIGN_IDENTITY:-${DEFAULT_IOS_DIST_CODESIGN_IDENTITY}}"
 
             # Turtle Specific overrides
             TURTLE_EXTRA_BUILD_ARGS="${TURTLE_EXTRA_BUILD_ARGS} --team-id ${IOS_DIST_APPLE_ID} --dist-p12-path ${IOS_DIST_P12_FILE} --provisioning-profile-path ${IOS_DIST_PROVISIONING_PROFILE}"

--- a/cli/runExpoAppPublish.sh
+++ b/cli/runExpoAppPublish.sh
@@ -640,6 +640,10 @@ function main() {
                     # codesigning setup
                     fastlane run import_certificate certificate_path:"${OPS_PATH}/ios_distribution.p12" certificate_password:"${IOS_DIST_P12_PASSWORD}" keychain_path:"${FASTLANE_KEYCHAIN_PATH}" keychain_password:"${FASTLANE_KEYCHAIN_NAME}" log_output:"true" || return $?
                     CODESIGN_IDENTITY="$( security find-certificate -c "${IOS_CODESIGN_IDENTITY}" -p "${FASTLANE_KEYCHAIN_PATH}"  |  openssl x509 -noout -subject -nameopt multiline | grep commonName | sed -n 's/ *commonName *= //p' )"
+                    if [[ -z "${CODESIGN_IDENTITY}" ]]; then
+                        fatal "Could not find code signing identity matching type: ${IOS_CODESIGN_IDENTITY} - To get the identity download the distribution certificate and get the commonName. The IOS_CODESIGN_IDENTITY is the bit before the : ( will be Apple Distribution or iPhone Distribution"
+                        return 255
+                    fi
 
                     # load the app provisioning profile
                     fastlane run install_provisioning_profile path:"${IOS_DIST_PROVISIONING_PROFILE}" || return $?


### PR DESCRIPTION
## Description

Allows for configuring the code sign identity for IOS builds

## Motivation and Context

This allows support for the newer Apple Distribution certificates which replace the existing iPhone Distribution certificates

## How Has This Been Tested?
Will test on active deployment

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
