### PR TITLE
fix: url image source updates

### DIFF
--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -305,6 +305,7 @@ function get_openapi_definition_file() {
   cp "${openapi_file_dir}/definition.json" "${definition_file}" ||
       { popTempDir; return 1; }
 
+  assemble_composite_definitions
   popTempDir
   return 0
 }
@@ -636,7 +637,6 @@ function process_template_pass() {
         [[ "${differences_detected}" == "true" ]] &&
           . "${result_file}" ||
           . "${output_file}"
-        assemble_composite_definitions
       fi
       ;;
 

--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -2844,9 +2844,8 @@ function update_build_reference_from_image {
   local image_format="$1"; shift
   local source="$1"; shift
 
-  info "Updating build reference..."
-  local settings_dir="$(findGen3ProductSettingsDir "${root_dir}" "${product}" )"
-  local build_dir="$(findGen3ProductBuildsDir "${root_dir}" "${product}" )"
+  local settings_dir="$(findGen3ProductSettingsDir "${ROOT_DIR}" "${product}" )"
+  local build_dir="$(findGen3ProductBuildsDir "${ROOT_DIR}" "${product}" )"
 
   [[ "${build_dir}" == "${settings_dir}" ]] && build_dir="${settings_dir}"
   local build_unit_path="${build_dir}/${environment}/${segment}/${build_unit}"
@@ -2957,9 +2956,8 @@ function get_image_from_container_registry() {
     docker image push "${registry_image}" || return $?
 
     # Update build references to use the new image
-    docker image prune
+    docker image prune --force
     build_reference="$( docker image inspect "${source_image}" --format '{{join .RepoDigests ";"}}' )"
-    warning "build ref ${build_reference}"
 
     update_build_reference_from_image "${product}" "${environment}" "${segment}" "${build_unit}" "${build_reference}" "${image_format}" "${source_image}"
   fi


### PR DESCRIPTION
## Description
- Set the root dir correctly when updating settings
- move definition update to only apply on api definition updates
- add force on docker prune to remove prompt

## Motivation and Context
- When updating build reference in a hamlet environment with two products in different tenants the update was applied in the wrong location 
- definition update only applies to the api gateway, we now use pregeneration for other purposes 
- docker prune was waiting for a confirmation 

## How Has This Been Tested?
tested locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
