### PR TITLE
feat: whatif input source

### DIFF
--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -139,7 +139,7 @@ function options() {
   fi
 
   # Input control for composite/CMDB input
-  if [[ "${GENERATION_INPUT_SOURCE}" == "composite" ]]; then
+  if [[ "${GENERATION_INPUT_SOURCE}" == "composite" || "${GENERATION_INPUT_SOURCE}" == "whatif" ]]; then
 
     # Set up the context
     . "${GENERATION_BASE_DIR}/execution/setContext.sh"
@@ -184,7 +184,7 @@ function options() {
   fi
 
   # Specific input control for mock input
-  if [[ "${GENERATION_INPUT_SOURCE}" == "mock" ]]; then
+  if [[ "${GENERATION_INPUT_SOURCE}" == "mock" || "${GENERATION_INPUT_SOURCE}" == "whatif" ]]; then
     if [[ -z "${OUTPUT_DIR}" ]]; then
       fatal "OUTPUT_DIR required for mock input source"
       fatalMandatory

--- a/execution/setContext.sh
+++ b/execution/setContext.sh
@@ -133,7 +133,7 @@ export GENERATION_INPUT_SOURCE="${GENERATION_INPUT_SOURCE:-"composite"}"
 # Cache for asssembled components
 export CACHE_DIR="$( getCacheDir "${GENERATION_CACHE_DIR}" )"
 
-if [[ "${GENERATION_INPUT_SOURCE}" == "composite" ]]; then
+if [[ "${GENERATION_INPUT_SOURCE}" == "composite" || "${GENERATION_INPUT_SOURCE}" == "whatif" ]]; then
 
     blueprint_alternate_dirs=( \
     "${SEGMENT_SOLUTIONS_DIR}" \


### PR DESCRIPTION

## Description
Supports the whatif input source. When the whatif input source is specified we should still assemble the composite CMDB like we normally do but require that outputs are sent to an external directory to avoid mock contaminating the composite CMDB

## Motivation and Context
Allows for testing changes to a CMDB without requiring dependent deployments 

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
