### PR TITLE
feat(expo): set encryption exemption on upload

### DIFF
--- a/cli/runExpoAppPublish.sh
+++ b/cli/runExpoAppPublish.sh
@@ -781,14 +781,7 @@ function main() {
                         info "Submitting IOS binary to testflight"
                         export FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD="${IOS_TESTFLIGHT_PASSWORD}"
 
-                        testflight_args=""
-                        if [[ "${IOS_DIST_NON_EXEMPT_ENCRYPTION,,}" == "true" ]]; then
-                            testflight_args="${testflight_args} uses_non_exempt_encryption:true skip_waiting_for_build_processing:false"
-                        else
-                            testflight_args="${testflight_args} skip_waiting_for_build_processing:true"
-                        fi
-
-                        fastlane run upload_to_testflight ${testflight_args} apple_id:"${IOS_DIST_APP_ID}" ipa:"${EXPO_BINARY_FILE_PATH}" username:"${IOS_TESTFLIGHT_USERNAME}" || return $?
+                        fastlane run upload_to_testflight uses_non_exempt_encryption:"${IOS_DIST_NON_EXEMPT_ENCRYPTION,,}" apple_id:"${IOS_DIST_APP_ID}" ipa:"${EXPO_BINARY_FILE_PATH}" username:"${IOS_TESTFLIGHT_USERNAME}" || return $?
                         DETAILED_HTML_BINARY_MESSAGE="${DETAILED_HTML_BINARY_MESSAGE}<strong> Submitted to TestFlight</strong>"
 
                         ;;

--- a/cli/runExpoAppPublish.sh
+++ b/cli/runExpoAppPublish.sh
@@ -483,8 +483,8 @@ function main() {
   get_configfile_property "${CONFIG_FILE}" "IOS_DIST_NON_EXEMPT_ENCRYPTION" "${KMS_PREFIX}" "${AWS_REGION}"
   IOS_DIST_NON_EXEMPT_ENCRYPTION="${IOS_DIST_NON_EXEMPT_ENCRYPTION:-${DEFAULT_IOS_DIST_NON_EXEMPT_ENCRYPTION}}"
 
-  jq --arg IOS_NON_EXEMPT_ENCRYPTION "${IOS_DIST_NON_EXEMPT_ENCRYPTION}" '.expo.ios.config.usesNonExemptEncryption=$IOS_NON_EXEMPT_ENCRYPTION' <  "./app.json" > "${tmpdir}/ios-bundle-app.json"
-  mv "${tmpdir}/ios-bundle-app.json" "./app.json"
+  jq --arg IOS_NON_EXEMPT_ENCRYPTION "${IOS_DIST_NON_EXEMPT_ENCRYPTION}" '.expo.ios.config.usesNonExemptEncryption=$IOS_NON_EXEMPT_ENCRYPTION' <  "./app.json" > "${tmpdir}/ios-encexempt-app.json"
+  mv "${tmpdir}/ios-encexempt-app.json" "./app.json"
 
   ANDROID_DIST_BUNDLE_ID="$( jq -r '.BuildConfig.ANDROID_DIST_BUNDLE_ID' < "${CONFIG_FILE}" )"
   if [[ "${ANDROID_DIST_BUNDLE_ID}" != "null" && -n "${ANDROID_DIST_BUNDLE_ID}" ]]; then

--- a/cli/runExpoAppPublish.sh
+++ b/cli/runExpoAppPublish.sh
@@ -483,7 +483,7 @@ function main() {
   get_configfile_property "${CONFIG_FILE}" "IOS_DIST_NON_EXEMPT_ENCRYPTION" "${KMS_PREFIX}" "${AWS_REGION}"
   IOS_DIST_NON_EXEMPT_ENCRYPTION="${IOS_DIST_NON_EXEMPT_ENCRYPTION:-${DEFAULT_IOS_DIST_NON_EXEMPT_ENCRYPTION}}"
 
-  jq --arg IOS_NON_EXEMPT_ENCRYPTION "${IOS_DIST_NON_EXEMPT_ENCRYPTION}" '.expo.ios.config.usesNonExemptEncryption=$IOS_NON_EXEMPT_ENCRYPTION' <  "./app.json" > "${tmpdir}/ios-encexempt-app.json"
+  jq --arg IOS_NON_EXEMPT_ENCRYPTION "${IOS_DIST_NON_EXEMPT_ENCRYPTION}" '.expo.ios.config.usesNonExemptEncryption=($IOS_NON_EXEMPT_ENCRYPTION | test("true"))' <  "./app.json" > "${tmpdir}/ios-encexempt-app.json"
   mv "${tmpdir}/ios-encexempt-app.json" "./app.json"
 
   ANDROID_DIST_BUNDLE_ID="$( jq -r '.BuildConfig.ANDROID_DIST_BUNDLE_ID' < "${CONFIG_FILE}" )"

--- a/cli/runExpoAppPublish.sh
+++ b/cli/runExpoAppPublish.sh
@@ -178,11 +178,6 @@ function env_setup() {
     pip3 install \
         awscli \
         yq || return $?
-
-    # yarn install
-    yarn global add \
-        expo-cli@"${EXPO_VERSION}" \
-        turtle-cli@"${DEFAULT_TURTLE_VERSION}" || return $?
 }
 
 function usage() {

--- a/cli/runExpoAppPublish.sh
+++ b/cli/runExpoAppPublish.sh
@@ -793,8 +793,7 @@ function main() {
 
                         info "Submitting IOS binary to testflight"
                         export FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD="${IOS_TESTFLIGHT_PASSWORD}"
-
-                        fastlane run upload_to_testflight skip_waiting_for_build_processing:"true" apple_id:"${IOS_DIST_APP_ID}" ipa:"${EXPO_BINARY_FILE_PATH}" username:"${IOS_TESTFLIGHT_USERNAME}" || return $?
+                        fastlane run upload_to_testflight skip_waiting_for_build_processing:true apple_id:"${IOS_DIST_APP_ID}" ipa:"${EXPO_BINARY_FILE_PATH}" username:"${IOS_TESTFLIGHT_USERNAME}" || return $?
                         DETAILED_HTML_BINARY_MESSAGE="${DETAILED_HTML_BINARY_MESSAGE}<strong> Submitted to TestFlight</strong>"
 
                         ;;

--- a/cli/runExpoAppPublish.sh
+++ b/cli/runExpoAppPublish.sh
@@ -781,7 +781,7 @@ function main() {
                         info "Submitting IOS binary to testflight"
                         export FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD="${IOS_TESTFLIGHT_PASSWORD}"
 
-                        fastlane run upload_to_testflight uses_non_exempt_encryption:"${IOS_DIST_NON_EXEMPT_ENCRYPTION,,}" apple_id:"${IOS_DIST_APP_ID}" ipa:"${EXPO_BINARY_FILE_PATH}" username:"${IOS_TESTFLIGHT_USERNAME}" || return $?
+                        fastlane run upload_to_testflight skip_waiting_for_build_processing:"true" uses_non_exempt_encryption:"${IOS_DIST_NON_EXEMPT_ENCRYPTION,,}" apple_id:"${IOS_DIST_APP_ID}" ipa:"${EXPO_BINARY_FILE_PATH}" username:"${IOS_TESTFLIGHT_USERNAME}" || return $?
                         DETAILED_HTML_BINARY_MESSAGE="${DETAILED_HTML_BINARY_MESSAGE}<strong> Submitted to TestFlight</strong>"
 
                         ;;


### PR DESCRIPTION

## Description
Allows for providing encryption exemption status as part of the testflight submission process. This handles a manual step required on each upload to the Testflight store

## Motivation and Context
Removes the need for testflight uploads to be held up by manual process

## How Has This Been Tested?
Will test on development environment 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
