### PR TITLE
refactor: try and always populate cmdb root dir

### DIFF
--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -479,7 +479,8 @@ function process_template_pass() {
     args+=("-r" "${composite,,}List=${composite_var#/?/}")
   done
 
-  args+=("-g" "${GENERATION_DATA_DIR}")
+  args+=( "-g" "${GENERATION_DATA_DIR:-$(findGen3RootDir "${ROOT_DIR:-$(pwd)}")}" )
+
   args+=("-v" "region=${region}")
   args+=("-v" "accountRegion=${account_region}")
   args+=("-v" "pluginState=${PLUGIN_STATE}")


### PR DESCRIPTION


## Description
Ensure a value is provided to the `-g` switch of the freemarker wrapper where possible.

## Motivation and Context
The cmdb migration support needs to know where to look for cmdbs, even if most processing of the cmdb has been disabled e.g. via the `-i mock` switch.

## How Has This Been Tested?
Local template testing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
