### PR TITLE
feat(automation): add ref for account repos

### DIFF
--- a/automation/constructTree.sh
+++ b/automation/constructTree.sh
@@ -9,6 +9,8 @@ REFERENCE_MASTER="master"
 # Defaults
 PRODUCT_CONFIG_REFERENCE_DEFAULT="${REFERENCE_MASTER}"
 PRODUCT_INFRASTRUCTURE_REFERENCE_DEFAULT="${REFERENCE_MASTER}"
+ACCOUNT_CONFIG_REFERENCE_DEFAULT="${REFERENCE_MASTER}"
+ACCOUNT_INFRASTRUCTURE_REFERENCE_DEFAULT="${REFERENCE_MASTER}"
 GENERATION_BIN_REFERENCE_DEFAULT="${REFERENCE_MASTER}"
 GENERATION_PATTERNS_REFERENCE_DEFAULT="${REFERENCE_MASTER}"
 GENERATION_STARTUP_REFERENCE_DEFAULT="${REFERENCE_MASTER}"
@@ -24,21 +26,22 @@ where
 
 (o) -a                                  if the account directories should not be included
 (o) -b GENERATION_BIN_REFERENCE         is the git reference for the generation framework bin repo
-(o) -c CONFIG_REFERENCE                 is the git reference for the config repo
+(o) -c PRODUCT_CONFIG_REFERENCE                 is the git reference for the config repo
 (o) -f                                  if patterns and startup repos required - only bin repo is included by default
     -h                                  shows this text
-(o) -i INFRASTRUCTURE_REFERENCE         is the git reference for the config repo
+(o) -i PRODUCT_INFRASTRUCTURE_REFERENCE         is the git reference for the config repo
 (o) -n                                  initialise repos if not already initialised
 (o) -p GENERATION_PATTERNS_REFERENCE    is the git reference for the generation framework patterns repo
 (o) -r                                  if the product directories should not be included
 (o) -s GENERATION_STARTUP_REFERENCE     is the git reference for the generation framework startup repo
-
+(o) -x ACCOUNT_CONFIG_REFERENCE         is the git ref for the acccount config repo
+(o) -y ACCOUNT_INFRASTRUCTURE_REFERENCE is the git ref for the acccount infrastructure repo
 (m) mandatory, (o) optional, (d) deprecated
 
 DEFAULTS:
 
-CONFIG_REFERENCE = ${PRODUCT_CONFIG_REFERENCE_DEFAULT}
-INFRASTRUCTURE_REFERENCE = ${PRODUCT_INFRASTRUCTURE_REFERENCE_DEFAULT}
+PRODUCT_CONFIG_REFERENCE = ${PRODUCT_CONFIG_REFERENCE_DEFAULT}
+PRODUCT_INFRASTRUCTURE_REFERENCE = ${PRODUCT_INFRASTRUCTURE_REFERENCE_DEFAULT}
 GENERATION_BIN_REFERENCE = ${GENERATION_BIN_REFERENCE_DEFAULT}
 GENERATION_PATTERNS_REFERENCE = ${GENERATION_PATTERNS_REFERENCE_DEFAULT}
 GENERATION_STARTUP_REFERENCE = ${GENERATION_STARTUP_REFERENCE_DEFAULT}
@@ -84,6 +87,12 @@ while getopts ":ab:c:fhi:np:rs:" opt; do
         s)
             GENERATION_STARTUP_REFERENCE="${OPTARG}"
             ;;
+        x)
+            ACCOUNT_CONFIG_REFERENCE="${OPTARG}"
+            ;;
+        y)
+            ACCOUNT_INFRASTRUCTURE_REFERENCE="${OPTARG}"
+            ;;
         \?)
             fatalOption
             ;;
@@ -96,6 +105,8 @@ done
 # Apply defaults
 PRODUCT_CONFIG_REFERENCE="${PRODUCT_CONFIG_REFERENCE:-$PRODUCT_CONFIG_REFERENCE_DEFAULT}"
 PRODUCT_INFRASTRUCTURE_REFERENCE="${PRODUCT_INFRASTRUCTURE_REFERENCE:-$PRODUCT_INFRASTRUCTURE_REFERENCE_DEFAULT}"
+ACCOUNT_CONFIG_REFERENCE="${ACCOUNT_CONFIG_REFERENCE:-$ACCOUNT_CONFIG_REFERENCE_DEFAULT}"
+ACCOUNT_INFRASTRUCTURE_REFERENCE="${ACCOUNT_INFRASTRUCTURE_REFERENCE:-$ACCOUNT_INFRASTRUCTURE_REFERENCE_DEFAULT}"
 GENERATION_BIN_REFERENCE="${GENERATION_BIN_REFERENCE:-$GENERATION_BIN_REFERENCE_DEFAULT}"
 GENERATION_PATTERNS_REFERENCE="${GENERATION_PATTERNS_REFERENCE:-$GENERATION_PATTERNS_REFERENCE_DEFAULT}"
 GENERATION_STARTUP_REFERENCE="${GENERATION_STARTUP_REFERENCE:-$GENERATION_STARTUP_REFERENCE_DEFAULT}"
@@ -110,6 +121,8 @@ INIT_REPOS="${INIT_REPOS:-false}"
 # Save for later steps
 save_context_property PRODUCT_CONFIG_REFERENCE "${PRODUCT_CONFIG_REFERENCE}"
 save_context_property PRODUCT_INFRASTRUCTURE_REFERENCE "${PRODUCT_INFRASTRUCTURE_REFERENCE}"
+save_context_property ACCOUNT_CONFIG_REFERENCE "${ACCOUNT_CONFIG_REFERENCE}"
+save_context_property ACCOUNT_INFRASTRUCTURE_REFERENCE "${ACCOUNT_INFRASTRUCTURE_REFERENCE}"
 
 # Record what is happening
 info "Creating the context directory tree"
@@ -248,7 +261,7 @@ if [[ !("${EXCLUDE_ACCOUNT_DIRECTORIES}" == "true") ]]; then
     if [[ -z "${ACCOUNT_CONFIG_DIR}" ]]; then
         ${AUTOMATION_DIR}/manageRepo.sh -c -l "account config" \
             -n "${ACCOUNT_CONFIG_REPO}" -v "${ACCOUNT_GIT_PROVIDER}" \
-            -d "${BASE_DIR_TEMP}"
+            -d "${BASE_DIR_TEMP}" -b "${ACCOUNT_CONFIG_REFERENCE}"
         RESULT=$? && [[ ${RESULT} -ne 0 ]] && exit
 
         # Ensure temporary files are ignored
@@ -297,7 +310,7 @@ if [[ !("${EXCLUDE_ACCOUNT_DIRECTORIES}" == "true") ]]; then
         # Pull in the account infrastructure repo
         ${AUTOMATION_DIR}/manageRepo.sh -c -l "account infrastructure" \
             -n "${ACCOUNT_INFRASTRUCTURE_REPO}" -v "${ACCOUNT_GIT_PROVIDER}" \
-            -d "${BASE_DIR_TEMP}"
+            -d "${BASE_DIR_TEMP}" -b "${ACCOUNT_INFRASTRUCTURE_REFERENCE}"
         RESULT=$? && [[ ${RESULT} -ne 0 ]] && exit
 
         # Ensure temporary files are ignored
@@ -403,4 +416,3 @@ upgrade_cmdb "${BASE_DIR}" ||
 
 # Remember directories for future steps
 save_gen3_dirs_in_context
-

--- a/automation/jenkins/aws/manageAccount.sh
+++ b/automation/jenkins/aws/manageAccount.sh
@@ -15,7 +15,7 @@ function main() {
   # save_repo "${ACCOUNT_DIR}" "account config" "${DETAIL_MESSAGE}" "${PRODUCT_CONFIG_REFERENCE}" || return $?
 
   # Commit the generated application templates/stacks
-  save_repo "${ACCOUNT_INFRASTRUCTURE_DIR}" "account infrastructure" "${DETAIL_MESSAGE}" "${PRODUCT_INFRASTRUCTURE_REFERENCE}" || return $?
+  save_repo "${ACCOUNT_INFRASTRUCTURE_DIR}" "account infrastructure" "${DETAIL_MESSAGE}" "${ACCOUNT_INFRASTRUCTURE_REFERENCE}" || return $?
 }
 
 main "$@"


### PR DESCRIPTION
## Description

Adds support for setting the ref to to use for account cmdbs inline with the configuration available for product CMDBDs

## Motivation and Context
During construct tree when cloning a repo which uses the main branch as the default branch the repo clone fails

## How Has This Been Tested?
Will be tested on deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
