### PR TITLE
fix: diagram file output naming

### DIFF
--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -385,7 +385,7 @@ function process_template_pass() {
   case "${entrance}" in
 
     # Outputs which don't belong to a deployment don't require region or account prefixes
-    unitlist|blueprint|buildblueprint|schema|loader|schemacontract)
+    unitlist|blueprint|buildblueprint|schema|loader|schemacontract|diagram|diagraminfo)
       for p in "${pass_list[@]}"; do
         pass_account_prefix["${p}"]=""
         pass_region_prefix["${p}"]=""
@@ -481,15 +481,15 @@ function process_template_pass() {
   done
 
   args+=( "-g" "${GENERATION_DATA_DIR:-$(findGen3RootDir "${ROOT_DIR:-$(pwd)}")}" )
-  
-  # Composites 
+
+  # Composites
   args+=("-v" "accountRegion=${account_region}")
   args+=("-v" "pluginState=${PLUGIN_STATE}")
   args+=("-v" "blueprint=${COMPOSITE_BLUEPRINT}")
   args+=("-v" "settings=${COMPOSITE_SETTINGS}")
   args+=("-v" "definitions=${COMPOSITE_DEFINITIONS}")
   args+=("-v" "stackOutputs=${COMPOSITE_STACK_OUTPUTS}")
-  
+
   # Run time references
   args+=("-v" "requestReference=${request_reference}")
   args+=("-v" "configurationReference=${configuration_reference}")


### PR DESCRIPTION
## Description
Minor fix to remove the region and account details when generating diagram outputs

## Motivation and Context
These attributes are not relevant for diagram details which focus on the overall solution

## How Has This Been Tested?
Tested locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
