### PR TITLE
feat: engine status codes

### DIFF
--- a/execution/freemarker.sh
+++ b/execution/freemarker.sh
@@ -49,9 +49,10 @@ RAW_VARIABLES=()
 VARIABLES=()
 CMDBS=()
 CMDB_MAPPINGS=()
+ENGINE_OUTPUT="/dev/stdout"
 
 # Parse options
-while getopts ":b:c:d:g:hl:o:r:t:v:" opt; do
+while getopts ":b:c:d:e:g:hl:o:r:t:v:" opt; do
     case $opt in
         b)
             BASE_CMDB="${OPTARG}"
@@ -61,6 +62,9 @@ while getopts ":b:c:d:g:hl:o:r:t:v:" opt; do
             ;;
         d)
             TEMPLATEDIRS+=("${OPTARG}")
+            ;;
+        e)
+            ENGINE_OUTPUT="${OPTARG}"
             ;;
         g)
             CMDB_MAPPINGS+=("${OPTARG}")
@@ -127,5 +131,5 @@ java -jar "${GENERATION_ENGINE_DIR}/bin/freemarker-wrapper-1.12.3.jar" \
     "${CMDB_MAPPINGS[@]}" \
     ${BASE_CMDB:+-b "${BASE_CMDB}"} \
     ${LOGLEVEL:+--${LOGLEVEL}} \
-    "${CMDBS[@]}"
+    "${CMDBS[@]}" &> ${ENGINE_OUTPUT}
 RESULT=$?


### PR DESCRIPTION
## Description
Refactor the template creation process to better capture and analyse the output of the freemarker wrapper. Also return specific return codes for `#stop` requests and for template processing errors.

## Motivation and Context
By identifying these conditions, it is possible to integrate this with more general automation to report template generation failures as soon as they occur.


## How Has This Been Tested?
Local testing in conjunction with https://github.com/hamlet-io/engine/pull/1556

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
