### PR TITLE
refactor: log level comparison

### DIFF
--- a/execution/common.sh
+++ b/execution/common.sh
@@ -21,6 +21,8 @@ HAMLET_HOME_DIR="${HAMLET_HOME_DIR:-"${HOME}/.hamlet"}"
 GENERATION_CACHE_DIR="${HAMLET_HOME_DIR}/cache"
 PLUGIN_CACHE_DIR="${HAMLET_HOME_DIR}/plugins"
 
+# Set the log level if not set
+GENERATION_LOG_LEVEL="${GENERATION_LOG_LEVEL:-${LOG_LEVEL_INFORMATION}}"
 function getLogLevel() {
   checkLogLevel "${GENERATION_LOG_LEVEL}"
 }

--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -60,7 +60,7 @@ function outputLogEntry() {
 function willLog() {
   local severity="$1"
 
-  [[ ${LOG_LEVEL_ORDER[$(getLogLevel)]} -le ${LOG_LEVEL_ORDER[${severity}]} ]]
+  (( "${LOG_LEVEL_ORDER[$(getLogLevel)]}" <= "${LOG_LEVEL_ORDER[${severity}]}" ))
 }
 
 function message() {


### PR DESCRIPTION
## Description

- Uses numeric function to determine the appropriate log level which allows for less or greater than and  equal to functions

- Sets the default log level to `info` to ensure a log level is always set

## Motivation and Context

Aligns with the engine behaviour which uses equal to in comparison
Makes it easier to understand how the logging levels work and what they should do

## How Has This Been Tested?

Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
