### PR TITLE
feat(util): aws vpn connection tunnel ip

### DIFF
--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -1821,6 +1821,14 @@ function get_transitgateway_vpn_attachment() {
 }
 
 # -- VPN Gateway --
+function get_vpn_connection_tunnel_ips() {
+  local region="${1}"; shift
+  local cfnStackName="$1"; shift
+  local vpnConnectionId="${1}"; shift
+
+  vpnConnection="$(get_cloudformation_stack_output "${region}" "${cfnStackName}" "${vpnConnectionId}" "ref" || return $?)"
+  echo "$( aws --region "${region}" ec2 describe-vpn-connections --output text --filters Name=vpn-connection-id,Values="${vpnConnection}" --query 'VpnConnections[0].VgwTelemetry[*].OutsideIpAddress' || return $? ) )"
+}
 
 function update_vpn_options() {
   local region="${1}"; shift

--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -1827,7 +1827,7 @@ function get_vpn_connection_tunnel_ips() {
   local vpnConnectionId="${1}"; shift
 
   vpnConnection="$(get_cloudformation_stack_output "${region}" "${cfnStackName}" "${vpnConnectionId}" "ref" || return $?)"
-  echo "$( aws --region "${region}" ec2 describe-vpn-connections --output text --filters Name=vpn-connection-id,Values="${vpnConnection}" --query 'VpnConnections[0].VgwTelemetry[*].OutsideIpAddress' || return $? ) )"
+  echo "$( aws --region "${region}" ec2 describe-vpn-connections --output text --vpn-connection-ids ${vpnConnection} --query 'VpnConnections[0].VgwTelemetry[*].OutsideIpAddress' || return $? ) )"
 }
 
 function update_vpn_options() {


### PR DESCRIPTION
## Description

Adds bash util to find the IP Addresses for a VPN Connection for https://github.com/hamlet-io/engine-plugin-aws/pull/253

## Motivation and Context

The IP address for the tunnels isn't available through cloudformation and its useful for monitoring the status of the tunnel

## How Has This Been Tested?

Tested locally

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

- [x] None

## Checklist:

- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
