### PR TITLE
feat: pass outputfilename from gen contract

### DIFF
--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -322,6 +322,7 @@ function process_template_pass() {
   local pass="${1,,}"; shift
   local pass_alternative="${1,,}"; shift
   local level="${1,,}"; shift
+  local output_file_name="${1,,}"; shift
   local deployment_unit="${1,,}"; shift
   local deployment_group="${1,,}"; shift
   local resource_group="${1,,}"; shift
@@ -483,6 +484,7 @@ function process_template_pass() {
   [[ -n "${deployment_unit}" ]]           && args+=("-v" "deploymentUnit=${deployment_unit}")
   [[ -n "${deployment_group}" ]]          && args+=("-v" "deploymentGroup=${deployment_group}")
   [[ -n "${resource_group}" ]]            && args+=("-v" "resourceGroup=${resource_group}")
+  [[ -n "${output_file_name}" ]]          && args+=("-v" "outputFileName=${output_file_name}")
   [[ -n "${GENERATION_LOG_LEVEL}" ]]      && args+=("-v" "logLevel=${GENERATION_LOG_LEVEL}")
   [[ -n "${GENERATION_LOG_LEVEL}" ]]      && args+=("-l" "${GENERATION_LOG_LEVEL}")
   [[ -n "${GENERATION_INPUT_SOURCE}" ]]   && args+=("-v" "inputSource=${GENERATION_INPUT_SOURCE}")
@@ -921,6 +923,7 @@ function process_template() {
       "generation-contract.json" \
       "generationcontract" \
       "" \
+      "" \
       "${level}" \
       "${deployment_unit}" \
       "${deployment_group}" \
@@ -981,7 +984,7 @@ function process_template() {
     process_template_pass \
       "${entrance}" \
       "${flows}" \
-      "${task_parameters[@]:0:7}" \
+      "${task_parameters[@]:0:8}" \
       "${level}" \
       "${deployment_unit}" \
       "${deployment_group}" \


### PR DESCRIPTION
## Description

bash implementation updates for https://github.com/hamlet-io/engine/pull/1583

- Removes file naming from the executor and relies on the engine and the generation-contract to handle file naming 
- Removes the level attribute and replaces it with the deployment group property. This was partially complete and has now been completed
- Removes the ability to specify the DEPLOYMENT_UNIT_SUBSET in deployments. Recommendation is to use deployment groups and resource sets for this functionality 
- Makes the tmp output dir that is used during generation a CMDB ( includes a .cmdb file ) so that the engine can write to the tmp directory as it requires ( using the engine toCMDB methods ) 
- The file provided to the engine via the -o flag is now used to store the output generation log instead of including this as part of the templates 
    - Uses this file to look for log messages from the hamlet engine 
    - This also allows us to log warning messages without impacting template generation or a deployment 
- Fixes an issue in selecting the output directory for non deployment outputs where the level was used instead of the entrance to choose files.
- Adds an explicit mapping of contract parameters to an ordered options list. This ensures that the ordering of contract arguments aligns with the bash function that is being called 
 

## Motivation and Context

Move file naming into the engine instead of being handled in the exectuor

## How Has This Been Tested?

Tested locally 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

- [x] None

## Checklist:

- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
