### PR TITLE
refactor: only get credentials when required

### DIFF
--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -720,6 +720,9 @@ function process_template_pass() {
 
       if [[ "${pass}" == "pregeneration" ]]; then
         info " ~ processing pregeneration script"
+
+        . "${GENERATION_BASE_DIR}/execution/setCredentials.sh"
+
         [[ "${differences_detected}" == "true" ]] &&
           . "${result_file}" ||
           . "${output_file}"
@@ -978,7 +981,7 @@ function process_template() {
     process_template_pass \
       "${entrance}" \
       "${flows}" \
-      "${task_parameters[@]}" \
+      "${task_parameters[@]:0:7}" \
       "${level}" \
       "${deployment_unit}" \
       "${deployment_group}" \

--- a/cli/manageCrypto.sh
+++ b/cli/manageCrypto.sh
@@ -156,6 +156,7 @@ function main() {
 
     # Set up the context - LOCATION will tell us where we are
     . "${GENERATION_BASE_DIR}/execution/setContext.sh"
+    . "${GENERATION_BASE_DIR}/execution/setCredentials.sh"
 
     # Set up the list of files to check
     FILES=()

--- a/cli/manageDeployment.sh
+++ b/cli/manageDeployment.sh
@@ -92,6 +92,7 @@ function options() {
   # Set up the context
   info "${DRYRUN}Preparing the context..."
   . "${GENERATION_BASE_DIR}/execution/setStackContext.sh"
+  . "${GENERATION_BASE_DIR}/execution/setCredentials.sh"
 
   RESOURCE_GROUP=${RESOURCE_GROUP:-${STACK_NAME}}
 

--- a/cli/manageSSLCertificate.sh
+++ b/cli/manageSSLCertificate.sh
@@ -113,6 +113,7 @@ esac
 
 # Set up the context
 . "${GENERATION_BASE_DIR}/execution/setContext.sh"
+. "${GENERATION_BASE_DIR}/execution/setCredentials.sh"
 
 case ${CERTIFICATE_OPERATION} in
     ${CERTIFICATE_OPERATION_LIST})

--- a/cli/manageStack.sh
+++ b/cli/manageStack.sh
@@ -89,6 +89,7 @@ function options() {
   # Set up the context
   info "${DRYRUN}Preparing the context..."
   . "${GENERATION_BASE_DIR}/execution/setStackContext.sh"
+  . "${GENERATION_BASE_DIR}/execution/setCredentials.sh"
 
   return 0
 }

--- a/cli/rebootRDSDatabase.sh
+++ b/cli/rebootRDSDatabase.sh
@@ -76,6 +76,7 @@ done
 
 # Set up the context
 . "${GENERATION_BASE_DIR}/execution/setContext.sh"
+. "${GENERATION_BASE_DIR}/execution/setCredentials.sh"
 
 status_file="$(getTopTempDir)/reboot_rds_status.txt"
 

--- a/cli/runExpoAppPublish.sh
+++ b/cli/runExpoAppPublish.sh
@@ -88,6 +88,7 @@ npx_base_args="--quiet --ignore-existing --cache ${npm_tool_cache}"
 
 # Get the generation context so we can run template generation
 . "${GENERATION_BASE_DIR}/execution/setContext.sh"
+. "${GENERATION_BASE_DIR}/execution/setCredentials.sh"
 
 function get_configfile_property() {
     local configfile="$1"; shift

--- a/cli/runLambda.sh
+++ b/cli/runLambda.sh
@@ -90,6 +90,7 @@ function main() {
 
     # Set up the context
     . "${GENERATION_BASE_DIR}/execution/setContext.sh"
+    . "${GENERATION_BASE_DIR}/execution/setCredentials.sh"
 
     # Generate a build blueprint so that we can find out the source S3 bucket
     info "Generating blueprint to find details..."

--- a/cli/runPipeline.sh
+++ b/cli/runPipeline.sh
@@ -91,6 +91,7 @@ function main() {
 
     # Set up the context
     . "${GENERATION_BASE_DIR}/execution/setContext.sh"
+    . "${GENERATION_BASE_DIR}/execution/setCredentials.sh"
 
     # Ensure we are in the right place
     checkInSegmentDirectory

--- a/cli/runSentryRelease.sh
+++ b/cli/runSentryRelease.sh
@@ -107,6 +107,7 @@ function main() {
 
   # Get the generation context so we can run template generation
   . "${GENERATION_BASE_DIR}/execution/setContext.sh"
+  . "${GENERATION_BASE_DIR}/execution/setCredentials.sh"
 
   # Generate a build blueprint so that we can find out the source S3 bucket
   info "Generating blueprint to find details..."

--- a/cli/runTask.sh
+++ b/cli/runTask.sh
@@ -116,6 +116,7 @@ fi
 
 # Set up the context
 . "${GENERATION_BASE_DIR}/execution/setContext.sh"
+. "${GENERATION_BASE_DIR}/execution/setCredentials.sh"
 
 status_file="$(getTopTempDir)/run_task_status.txt"
 

--- a/cli/snapshotRDSDatabase.sh
+++ b/cli/snapshotRDSDatabase.sh
@@ -91,6 +91,7 @@ done
 
 # Set up the context
 . "${GENERATION_BASE_DIR}/execution/setContext.sh"
+. "${GENERATION_BASE_DIR}/execution/setCredentials.sh"
 
 status_file="$(getTopTempDir)/snapshot_rds_status.txt"
 

--- a/cli/updateObjectACL.sh
+++ b/cli/updateObjectACL.sh
@@ -77,6 +77,7 @@ DISPLAY_ACLS="${DISPLAY_ACLS:-${DISPLAY_ACLS_DEFAULT}}"
 
 # Set up the context
 . "${GENERATION_BASE_DIR}/execution/setContext.sh"
+. "${GENERATION_BASE_DIR}/execution/setCredentials.sh"
 
 # Get the list of ECS clusters
 for KEY in $(aws --region ${REGION} s3 ls s3://${BUCKET}${PREFIX} --recursive  | tr -s " " | tr -d "\r" | cut -d " " -f4); do

--- a/execution/setContext.sh
+++ b/execution/setContext.sh
@@ -239,66 +239,6 @@ if [[ "${GENERATION_INPUT_SOURCE}" == "composite" || "${GENERATION_INPUT_SOURCE}
 
 fi
 
-# Set default AWS credentials if available (hook from Jenkins framework)
-CHECK_AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-${ACCOUNT_TEMP_AWS_ACCESS_KEY_ID}}"
-CHECK_AWS_ACCESS_KEY_ID="${CHECK_AWS_ACCESS_KEY_ID:-${!ACCOUNT_AWS_ACCESS_KEY_ID_VAR}}"
-if [[ -n "${CHECK_AWS_ACCESS_KEY_ID}" ]]; then export AWS_ACCESS_KEY_ID="${CHECK_AWS_ACCESS_KEY_ID}"; fi
-
-CHECK_AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-${ACCOUNT_TEMP_AWS_SECRET_ACCESS_KEY}}"
-CHECK_AWS_SECRET_ACCESS_KEY="${CHECK_AWS_SECRET_ACCESS_KEY:-${!ACCOUNT_AWS_SECRET_ACCESS_KEY_VAR}}"
-if [[ -n "${CHECK_AWS_SECRET_ACCESS_KEY}" ]]; then export AWS_SECRET_ACCESS_KEY="${CHECK_AWS_SECRET_ACCESS_KEY}"; fi
-
-CHECK_AWS_SESSION_TOKEN="${AWS_SESSION_TOKEN:-${ACCOUNT_TEMP_AWS_SESSION_TOKEN}}"
-if [[ -n "${CHECK_AWS_SESSION_TOKEN}" ]]; then export AWS_SESSION_TOKEN="${CHECK_AWS_SESSION_TOKEN}"; fi
-
-# Set the profile for IAM access if AWS credentials not in the environment
-# We would normally redirect to /dev/null but this triggers an "unknown encoding"
-# bug in python
-if [[ ((-z "${AWS_ACCESS_KEY_ID}") || (-z "${AWS_SECRET_ACCESS_KEY}")) ]]; then
-    if [[ -n "${ACCOUNT}" ]]; then
-        aws configure list --profile "${ACCOUNT}" > $(getTempFile "account_profile_status_XXXXXX.txt") 2>&1
-        if [[ $? -eq 0 ]]; then
-            export AWS_DEFAULT_PROFILE="${ACCOUNT}"
-        fi
-    fi
-    if [[ -n "${AID}" ]]; then
-        aws configure list --profile "${AID}" > $(getTempFile "id_profile_status_XXXXXX.txt") 2>&1
-        if [[ $? -eq 0 ]]; then
-            export AWS_DEFAULT_PROFILE="${AID}"
-        fi
-    fi
-    if [[ $ACCOUNT_PROVIDER == 'aws' ]]; then
-        aws configure list --profile "${PROVIDERID}" > $(getTempFile "awsid_profile_status_XXXXXX.txt") 2>&1
-        if [[ $? -eq 0 ]]; then
-            export AWS_DEFAULT_PROFILE="${PROVIDERID}"
-        fi
-    fi
-fi
-
-# Set the Azure subscription and login if we haven't already
-if [[ "${ACCOUNT_PROVIDER}" == "azure" ]]; then
-    if [[ "${AZ_AUTH_METHOD}" == "none" ]]; then
-        info "Skipping azure authentication - AZ_AUTH_METHOD=${AZ_AUTH_METHOD}"
-    else
-        if [[ -z "$(az account list --output tsv)" ]]; then
-            info "Logging in to Azure..."
-            . ${AUTOMATION_DIR}/setCredentials.sh "${ACCOUNT}"
-
-        fi
-
-        if [[ "${AZ_AUTH_METHOD}" != "none" ]]; then
-            az_cli_args=()
-            # -- Only show errors unless debugging --
-            if willLog "${LOG_LEVEL_DEBUG}"; then
-                az_cli_args+=("--output" "json" )
-            else
-                az_cli_args+=("--output" "none" )
-            fi
-
-            az account set --subscription "${PROVIDERID}" "${az_cli_args[@]}"
-        fi
-    fi
-fi
 
 # Handle some MINGW peculiarities
 uname | grep -iq "MINGW64" && export MINGW64="true"

--- a/execution/setCredentials.sh
+++ b/execution/setCredentials.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+# Set up credentials to interact with cloud providers when running engine processes
+
+# Set default AWS credentials if available (hook from Jenkins framework)
+CHECK_AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-${ACCOUNT_TEMP_AWS_ACCESS_KEY_ID}}"
+CHECK_AWS_ACCESS_KEY_ID="${CHECK_AWS_ACCESS_KEY_ID:-${!ACCOUNT_AWS_ACCESS_KEY_ID_VAR}}"
+if [[ -n "${CHECK_AWS_ACCESS_KEY_ID}" ]]; then export AWS_ACCESS_KEY_ID="${CHECK_AWS_ACCESS_KEY_ID}"; fi
+
+CHECK_AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-${ACCOUNT_TEMP_AWS_SECRET_ACCESS_KEY}}"
+CHECK_AWS_SECRET_ACCESS_KEY="${CHECK_AWS_SECRET_ACCESS_KEY:-${!ACCOUNT_AWS_SECRET_ACCESS_KEY_VAR}}"
+if [[ -n "${CHECK_AWS_SECRET_ACCESS_KEY}" ]]; then export AWS_SECRET_ACCESS_KEY="${CHECK_AWS_SECRET_ACCESS_KEY}"; fi
+
+CHECK_AWS_SESSION_TOKEN="${AWS_SESSION_TOKEN:-${ACCOUNT_TEMP_AWS_SESSION_TOKEN}}"
+if [[ -n "${CHECK_AWS_SESSION_TOKEN}" ]]; then export AWS_SESSION_TOKEN="${CHECK_AWS_SESSION_TOKEN}"; fi
+
+# Set the profile for IAM access if AWS credentials not in the environment
+# We would normally redirect to /dev/null but this triggers an "unknown encoding"
+# bug in python
+if [[ ((-z "${AWS_ACCESS_KEY_ID}") || (-z "${AWS_SECRET_ACCESS_KEY}")) ]]; then
+    if [[ -n "${ACCOUNT}" ]]; then
+        aws configure list --profile "${ACCOUNT}" > $(getTempFile "account_profile_status_XXXXXX.txt") 2>&1
+        if [[ $? -eq 0 ]]; then
+            export AWS_DEFAULT_PROFILE="${ACCOUNT}"
+        fi
+    fi
+    if [[ -n "${AID}" ]]; then
+        aws configure list --profile "${AID}" > $(getTempFile "id_profile_status_XXXXXX.txt") 2>&1
+        if [[ $? -eq 0 ]]; then
+            export AWS_DEFAULT_PROFILE="${AID}"
+        fi
+    fi
+    if [[ $ACCOUNT_PROVIDER == 'aws' ]]; then
+        aws configure list --profile "${PROVIDERID}" > $(getTempFile "awsid_profile_status_XXXXXX.txt") 2>&1
+        if [[ $? -eq 0 ]]; then
+            export AWS_DEFAULT_PROFILE="${PROVIDERID}"
+        fi
+    fi
+fi
+
+# Set the Azure subscription and login if we haven't already
+if [[ "${ACCOUNT_PROVIDER}" == "azure" ]]; then
+    if [[ "${AZ_AUTH_METHOD}" == "none" ]]; then
+        info "Skipping azure authentication - AZ_AUTH_METHOD=${AZ_AUTH_METHOD}"
+    else
+        if [[ -z "$(az account list --output tsv)" ]]; then
+            info "Logging in to Azure..."
+            . ${AUTOMATION_DIR}/setCredentials.sh "${ACCOUNT}"
+
+        fi
+
+        if [[ "${AZ_AUTH_METHOD}" != "none" ]]; then
+            az_cli_args=()
+            # -- Only show errors unless debugging --
+            if willLog "${LOG_LEVEL_DEBUG}"; then
+                az_cli_args+=("--output" "json" )
+            else
+                az_cli_args+=("--output" "none" )
+            fi
+
+            az account set --subscription "${PROVIDERID}" "${az_cli_args[@]}"
+        fi
+    fi
+fi


### PR DESCRIPTION
## Description

In the bash executor cli only get the credentials for cloud providers when they are required

With the use of more query tooling in the hamlet cli we generate templates which are used by a hamlet user to find out about thier deployment

## Motivation and Context

Fixes #173 


## How Has This Been Tested?

Tested locally

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

- [x] None

## Checklist:

- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
