### PR TITLE
refactor: remove startup script support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ These options must be set in order for Hamlet Deploy Executor to function correc
 | GENERATION_ENGINE_DIR   | A fully qualified filepath to a local copy of the Hamlet Deploy Engine Core repository.                      |
 | GENERATION_PATTERNS_DIR | A fully qualified filepath to a local copy of the Hamlet Deploy Patterns repository.                         |
 | GENERATION_PLUGIN_DIRS  | A semicolon delimited list of fully qualified filepaths, each to a local instance of a Hamlet Deploy Plugin. |
-| GENERATION_STARTUP_DIR  | A fully qualified filepath to a local copy of the Hamlet Deploy Startup repository.                          |
-
 
 #### Optional Variables
 

--- a/automation/constructTree.sh
+++ b/automation/constructTree.sh
@@ -381,25 +381,6 @@ if [[ -z "${GENERATION_PATTERNS_DIR}" ]]; then
     fi
 fi
 
-
-# Pull in the default generation startup repo if not overridden by product or locally installed
-if [[ -z "${GENERATION_STARTUP_DIR}" ]]; then
-    if [[ "${INCLUDE_ALL_REPOS}" == "true" ]]; then
-        GENERATION_STARTUP_DIR="${BASE_DIR}/startup"
-        PRODUCT_GENERATION_STARTUP_DIR="$(findDir "${BASE_DIR}" "${PRODUCT}/startup" )"
-        if [[ -n "${PRODUCT_GENERATION_STARTUP_DIR}" ]]; then
-            mkdir -p "${GENERATION_STARTUP_DIR}"
-            cp -rp "${PRODUCT_GENERATION_STARTUP_DIR}" "${GENERATION_STARTUP_DIR}"
-        else
-            ${AUTOMATION_DIR}/manageRepo.sh -c -l "generation startup" \
-                -n "${GENERATION_STARTUP_REPO}" -v "${GENERATION_GIT_PROVIDER}" \
-                -d "${GENERATION_STARTUP_DIR}" -b "${GENERATION_STARTUP_REFERENCE}"
-            RESULT=$? && [[ ${RESULT} -ne 0 ]] && exit
-        fi
-        save_context_property GENERATION_STARTUP_DIR "${GENERATION_STARTUP_DIR}"
-    fi
-fi
-
 # Examine the structure and define key directories
 
 findGen3Dirs "${BASE_DIR}"


### PR DESCRIPTION
## Description

Removes startup script setup from the executor.

## Motivation and Context

This functionality is now handled in the engine and script stores allow for sourcing startup repos from git based locations and s3 

## How Has This Been Tested?

Tested locally

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

- [x] None

## Checklist:

- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
