### PR TITLE
refactor: composite template inclusion

### DIFF
--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -378,7 +378,9 @@ function process_template_pass() {
   # It shouldn't affect other platforms as it won't be matched
   for composite in "${template_composites[@]}"; do
     composite_var="${CACHE_DIR}/composite_${composite,,}.ftl"
+    # TODO(mfl) Remove the -r variant once changes to engine in place to support -v
     args+=("-r" "${composite,,}List=${composite_var#/?/}")
+    args+=("-v" "${composite,,}Template=${composite_var}")
   done
 
   args+=( "-g" "${GENERATION_DATA_DIR:-$(findGen3RootDir "${ROOT_DIR:-$(pwd)}")}" )


### PR DESCRIPTION
## Description
Include the contents of pre-assembled composite templates rather than relying on the `[#include]` directive to process their content.

## Motivation and Context
As part of moving to dynamic input loading, reliance on pre-assembled templates needs to be removed. This change starts the process by using the `?interpret` builtin internally to avoid use of the `[#include]` directive.

## How Has This Been Tested?
Local template generation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] Remove the filename based variables once the following PRs has been merged;
- [x] Engine - https://github.com/hamlet-io/engine/pull/1613
- [x] AWS - https://github.com/hamlet-io/engine-plugin-aws/pull/266


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
