### PR TITLE
fix: plugin refresh should ignore modules

### DIFF
--- a/cli/setup.sh
+++ b/cli/setup.sh
@@ -67,7 +67,7 @@ function main() {
   GIT_CLONE_DIR="${PLUGIN_CACHE_DIR}/_git"
   PLUGIN_STATE_FILE="${PLUGIN_CACHE_DIR}/plugin-state.json"
 
-  ${GENERATION_DIR}/createTemplate.sh -p "shared" -e loader -y missingPluginAction=ignore -o "${LOADER_DIR}" ${TEMPLATE_ARGS} || return $?
+  ${GENERATION_DIR}/createTemplate.sh -p "shared" -e loader -y pluginRefreshRequired=true -o "${LOADER_DIR}" ${TEMPLATE_ARGS} || return $?
 
   # check for a plugin contract
   if [[ -f "${LOADER_DIR}/loader-plugincontract.json" &&  -s "${LOADER_DIR}/loader-plugincontract.json" ]]; then


### PR DESCRIPTION
## Description
Align to the changes in the engine in regards to the loader parameter used to detect when the plugin state should be generated.

## Motivation and Context
Part of fix for https://github.com/hamlet-io/engine/issues/1615

## How Has This Been Tested?
Local execution

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
