### PR TITLE
Chore/cleanup resource groups

### DIFF
--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -33,7 +33,6 @@ where
 (o) -d DEPLOYMENT_MODE         is the deployment mode the template will be generated for
 (o) -e ENTRANCE                is the hamlet entrance to start processing with
 (o) -f GENERATION_FRAMEWORK    is the output framework to use for template generation
-(o) -g RESOURCE_GROUP          is the deployment unit resource group
 (o) -i GENERATION_INPUT_SOURCE is the source of input data to use when generating the template - "composite", "mock"
     -h                         shows this text
 (m) -l LEVEL                   is the template level - "unitlist", "blueprint", "account", "segment", "solution" or "application"
@@ -69,14 +68,13 @@ EOF
 function options() {
 
   # Parse options
-  while getopts ":b:c:d:e:f:g:hi:l:o:p:q:r:u:xy:z:" option; do
+  while getopts ":b:c:d:e:f:hi:l:o:p:q:r:u:xy:z:" option; do
       case "${option}" in
           b) FLOWS_ARRAY+=("${OPTARG}") ;;
           c) CONFIGURATION_REFERENCE="${OPTARG}" ;;
           d) DEPLOYMENT_MODE="${OPTARG}" ;;
           e) ENTRANCE="${OPTARG}" ;;
           f) GENERATION_FRAMEWORK="${OPTARG}" ;;
-          g) RESOURCE_GROUP="${OPTARG}" ;;
           h) usage; return 1 ;;
           i) GENERATION_INPUT_SOURCE="${OPTARG}" ;;
           l) DEPLOYMENT_GROUP="${OPTARG}" ;;
@@ -319,7 +317,6 @@ function process_template_pass() {
   local deployment_unit="${1,,}"; shift
   local deployment_unit_subset="${1,,}"; shift
   local deployment_group="${1,,}"; shift
-  local resource_group="${1,,}"; shift
   local account="$1"; shift
   local account_region="${1,,}"; shift
   local region="${1,,}"; shift
@@ -366,7 +363,6 @@ function process_template_pass() {
   [[ -n "${deployment_unit}" ]]           && args+=("-r" "deploymentUnit=${deployment_unit}")
   [[ -n "${deployment_unit_subset}" ]]    && args+=("-r" "deploymentUnitSubset=${deployment_unit_subset}")
   [[ -n "${deployment_group}" ]]          && args+=("-r" "deploymentGroup=${deployment_group}")
-  [[ -n "${resource_group}" ]]            && args+=("-r" "resourceGroup=${resource_group}")
   [[ -n "${output_filename}" ]]           && args+=("-r" "outputFileName=${output_filename}")
   [[ -n "${GENERATION_INPUT_SOURCE}" ]]   && args+=("-r" "inputSource=${GENERATION_INPUT_SOURCE}")
 
@@ -688,7 +684,6 @@ function process_template() {
   local flows="${1,,}"; shift
   local deployment_unit="${1,,}"; shift
   local deployment_group="${1,,}"; shift
-  local resource_group="${1,,}"; shift
   local account="$1"; shift
   local account_region="${1,,}"; shift
   local region="${1,,}"; shift
@@ -817,7 +812,6 @@ function process_template() {
       "${deployment_unit}" \
       "generationcontract" \
       "${deployment_group}" \
-      "${resource_group}" \
       "${account}" \
       "${account_region}" \
       "${region}" \
@@ -866,7 +860,6 @@ function process_template() {
         "deploymentUnit"
         "deploymentUnitSubset"
         "deploymentGroup"
-        "resourceGroup"
         "account"
         "accountRegion"
         "region"
@@ -988,7 +981,7 @@ function main() {
   process_template \
     "${ENTRANCE}" \
     "${FLOWS}" \
-    "${DEPLOYMENT_UNIT}" "${DEPLOYMENT_GROUP}" "${RESOURCE_GROUP}" \
+    "${DEPLOYMENT_UNIT}" "${DEPLOYMENT_GROUP}" \
     "${ACCOUNT}" "${ACCOUNT_REGION}" \
     "${REGION}" \
     "${REQUEST_REFERENCE}" \

--- a/cli/manageDeployment.sh
+++ b/cli/manageDeployment.sh
@@ -19,12 +19,11 @@ function usage() {
 
   Manage an Azure Resource Manager (ARM) deployment
 
-  Usage: $(basename $0) -l LEVEL -r REGION -s DEPLOYMENT_SCOPE -u DEPLOYMENT_UNIT -n DEPLOYMENT_NAME
+  Usage: $(basename $0) -l LEVEL -r REGION -s DEPLOYMENT_SCOPE -u DEPLOYMENT_UNIT
 
   where
 
   (o) -d (DEPLOYMENT_OPERATION=delete)  to delete the deployment
-  (o) -g RESOURCE_GROUP                 Overrides the Resource Group to deploy into, default is to generate a deployment group per deployment unit
       -h                                shows this text
   (o) -i (DEPLOYMENT_MONITOR=false)     initiates but does not monitor the deployment operation.
   (m) -l LEVEL                          is the deployment level - "account", "product", "segment", "solution", "application" or "multiple"
@@ -56,7 +55,6 @@ function options() {
   while getopts ":dg:hil:mo:qr:s:u:w::yz:" option; do
     case "${option}" in
       d) DEPLOYMENT_OPERATION=delete ;;
-      g) RESOURCE_GROUP="${OPTARG}" ;;
       h) usage; return 1 ;;
       i) DEPLOYMENT_MONITOR=false ;;
       l) LEVEL="${OPTARG}" ;;


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
<!--- Describe your changes in detail -->
Removes old configuration that would allow you to set the deployment resource group in the executor. 

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The Deployment Resource Group is now defined by the engine, and is not exposed to users to control.

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Template generation to ensure this does not impact creation of templates.

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None
