### PR TITLE
fix: command line options of pass alternative

### DIFF
--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -359,6 +359,7 @@ function process_template_pass() {
   [[ -n "${entrance}" ]]                  && args+=("-r" "entrance=${entrance}")
   [[ -n "${flows}" ]]                     && args+=("-r" "flows=${flows}")
   [[ -n "${pass}" ]]                      && args+=("-r" "pass=${pass}")
+  [[ -n "${pass_alternative}" ]]          && args+=("-r" "passAlternative=${pass_alternative}")
   [[ -n "${providers}" ]]                 && args+=("-r" "providers=${providers}")
   [[ -n "${deployment_framework}" ]]      && args+=("-r" "deploymentFramework=${deployment_framework}")
   [[ -n "${output_type}" ]]               && args+=("-r" "outputType=${output_type}")
@@ -567,6 +568,16 @@ function process_template_pass() {
   if [[ -s "${generation_log_file}-warnings" ]]; then
     warning "! Warnings were found during template generation. Details follow...\n"
     cat "${generation_log_file}-warnings" >&2
+  fi
+
+  # debug
+  jq -r ".COTMessages | select(.!=null) | .[] | select(.Severity == \"debug\")" \
+    < "${generation_log_file}" > "${generation_log_file}-debugs"
+  jq -r ".HamletMessages | select(.!=null) | .[] | select(.Severity == \"debug\")" \
+    < "${generation_log_file}" >> "${generation_log_file}-debugs"
+  if [[ -s "${generation_log_file}-debugs" ]]; then
+    warning "! Debug messages were found during template generation. Details follow...\n"
+    cat "${generation_log_file}-debugs" >&2
   fi
 
   # Clean up the output file and check for change


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

- the pass alternative argument to the engine seems to have gone missing during recent changes. This puts  it back in
- Also adds debug log console output ( snuck along for the ride ) 

## Motivation and Context

Generation of alternative templates was not behaving as it should

## How Has This Been Tested?

Tested locally

## Followup Actions

- [x] None
