### PR TITLE
fix: freemarker output redirection

### DIFF
--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -452,7 +452,7 @@ function process_template_pass() {
   # The debug file is the default output and should only be used for serious debugging
   local debug_file="${tmp_dir}/${output_filename}.debug"
 
-  if ${GENERATION_BASE_DIR}/execution/freemarker.sh \
+  if ! ${GENERATION_BASE_DIR}/execution/freemarker.sh \
     -d "${template_dir}" \
     ${GENERATION_PRE_PLUGIN_DIRS:+ -d "${GENERATION_PRE_PLUGIN_DIRS}"} \
     -d "${GENERATION_ENGINE_DIR}/engine" \
@@ -461,8 +461,7 @@ function process_template_pass() {
     -t "${template}" \
     -o "${debug_file}" \
     "${args[@]}"; then
-      info "generation successful"
-  else
+
     # Capture the raw return code
     return_code=$?
 

--- a/execution/freemarker.sh
+++ b/execution/freemarker.sh
@@ -49,10 +49,9 @@ RAW_VARIABLES=()
 VARIABLES=()
 CMDBS=()
 CMDB_MAPPINGS=()
-ENGINE_OUTPUT="/dev/stdout"
 
 # Parse options
-while getopts ":b:c:d:e:g:hl:o:r:t:v:" opt; do
+while getopts ":b:c:d:g:hl:o:r:t:v:" opt; do
     case $opt in
         b)
             BASE_CMDB="${OPTARG}"
@@ -62,9 +61,6 @@ while getopts ":b:c:d:e:g:hl:o:r:t:v:" opt; do
             ;;
         d)
             TEMPLATEDIRS+=("${OPTARG}")
-            ;;
-        e)
-            ENGINE_OUTPUT="${OPTARG}"
             ;;
         g)
             CMDB_MAPPINGS+=("${OPTARG}")
@@ -131,5 +127,5 @@ java -jar "${GENERATION_ENGINE_DIR}/bin/freemarker-wrapper-1.13.0.jar" \
     "${CMDB_MAPPINGS[@]}" \
     ${BASE_CMDB:+-b "${BASE_CMDB}"} \
     ${LOGLEVEL:+--${LOGLEVEL}} \
-    "${CMDBS[@]}" &> ${ENGINE_OUTPUT}
+    "${CMDBS[@]}"
 RESULT=$?


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
- Freemarker wrapper now relies on its environment to control where stdout and stderr go.
- "Generation successful" messages after each successful invocation of the freemarker engine are no longer logged.

## Motivation and Context
Previously, the wrapper was always redirecting both stdout and stderr to the one target. With the changes to output handling in the wrapper and engine, the wrapper script now assumes the environment is set up to redirect output where required.

The logging of "generation successful" was removed to reduce the noise in the output generated during template creation.




## How Has This Been Tested?
Local template generation

## Followup Actions
- [x] None
