### PR TITLE
fix: region in filenames

### DIFF
--- a/execution/setContext.sh
+++ b/execution/setContext.sh
@@ -113,6 +113,11 @@ popd >/dev/null
 # default for the CF_DIR
 findGen3Dirs "${GENERATION_DATA_DIR}" || exit
 
+if [[ "${GENERATION_USE_CMDB_PLUGIN}" == "true" ]]; then
+    debug "--- finished setContext.sh ---\n"
+    return 0
+fi
+
 # Build the composite solution ( aka blueprint)
 # TODO(mfl)  Remove this once the engine is completely controlling where outputs are put
 # Currently a few of the variables like REGION are used in file naming


### PR DESCRIPTION
## Intent of Change
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
If using the CMDB plugin, bypass the generation of the blueprint. 

## Motivation and Context
It was needed to inject the region information as command line options for the engine but this can now be sourced in the engine from the CMDB.

## How Has This Been Tested?
Local template generation both with and without the CMDB plugin.

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
- engine - https://github.com/hamlet-io/engine/pull/1667

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

