### PR TITLE
feat: set key scope for out of repo crypto

### DIFF
--- a/cli/manageCrypto.sh
+++ b/cli/manageCrypto.sh
@@ -41,7 +41,7 @@ where
 (o) -p JSON_PATH    is the path to the attribute within CRYPTO_FILE to be processed
 (o) -q              don't display result (quiet)
 (o) -r              re-encrypt operation
-(o) -s KEY_SCOPE    the sope of the key to use ( segment or account ) - current location wins over default
+(o) -s KEY_SCOPE    the scope of the key to use ( segment or account ) - current location wins over default
 (o) -t CRYPTO_TEXT  is the plaintext or ciphertext to be processed
     -u              update the attribute at JSON_PATH (if provided), or replace CRYPTO_FILE with operation result
     -v              result is base64 decoded (visible)


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

Adds the key scope parameter which acts as fall back when the LOCATION can not be determined in set context. This allows for the manageCrypto command to run when you aren't in the CMDB segment or account dir and running commands using env vars for context. LOCATION is still preferred over the scope for backwards compatibility 

## Motivation and Context

This allows for running manage crypto with the python executor when you aren't in the CMDB and instead have set a profile to control the context 

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

