### PR TITLE
feat: filter contract steps based on status

### DIFF
--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -788,7 +788,7 @@ function getTasksFromContract() {
 
     arrayFromList stage_list "$( jq -r '.Stages[].Id' < "${contractFile}" || return $?)"
     for stageIndex in "${!stage_list[@]}"; do
-        arrayFromList stage_steps_list "$( jq -r --arg stageIndex "${stageIndex}" '.Stages[$stageIndex | tonumber].Steps[].Id' < "${contractFile}" || return $? )"
+        arrayFromList stage_steps_list "$( jq -r --arg stageIndex "${stageIndex}" '.Stages[$stageIndex | tonumber].Steps[] | select(.Status == "available" ) | .Id' < "${contractFile}" || return $? )"
         for stepIndex in "${!stage_steps_list[@]}"; do
             getTaskFromContractStep >> "${tmp_file}"
         done


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

Adds a filter on contract steps to only execute the contract steps which are available and haven't already been completed

## Motivation and Context

Since the engine can now execute steps in a contract before the executor sees the contract we need to filter out steps which have already been completed. 

## How Has This Been Tested?

Tested locally

## Related Changes

### Prerequisite PRs:

- https://github.com/hamlet-io/engine/pull/1671

### Dependent PRs:

- None

### Consumer Actions:

- None

