### PR TITLE
fix(expo): reduce version code for android

### DIFF
--- a/cli/runExpoAppPublish.sh
+++ b/cli/runExpoAppPublish.sh
@@ -720,7 +720,8 @@ function main() {
 
                     # Bundle Overrides
                     export ANDROID_DIST_BUNDLE_ID="${ANDROID_DIST_BUNDLE_ID}"
-                    export ANDROID_VERSION_CODE="$( echo "${BUILD_NUMBER//".1"}" | cut -c 3- | rev | cut -c 3- | rev )"
+                    # Handle Google Id formatting rules ( https://developer.android.com/studio/publish/versioning.html )
+                    export ANDROID_VERSION_CODE="$( echo "${BUILD_NUMBER//".1"}" | cut -c 3- | rev | cut -c 3- | rev | cut -c -9)"
                     export ANDROID_VERSION_NAME="${EXPO_APP_VERSION}"
 
                     if [[ -e "${SRC_PATH}/android/app/src/main/AndroidManifest.xml" ]]; then


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

Google Play only supports Id numbers up to 2100000000 so we just need to
make the date stamp shorter. Making it 9 numbers long to make sure we
don't hit this again

## Motivation and Context

Mobile app versions 🙄 ...

## How Has This Been Tested?

Will be tested on local deployment

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

