### PR TITLE
refactor: dynamic cmdb plugin detection

### DIFF
--- a/execution/common.sh
+++ b/execution/common.sh
@@ -36,7 +36,7 @@ export GENERATION_LOG_FORMAT="${GENERATION_LOG_FORMAT:-${LOG_FORMAT_COMPACT}}"
 # Determine if using the cmdb plugin
 # Provide an explicit override as well
 # TODO(mfl) remove once migration to the cmdb plugin is complete and proven
-if contains "${GENERATION_PLUGIN_DIRS}" "(engine-plugin-cmdb|cmdb;)"; then
+if contains "${GENERATION_PLUGIN_DIRS};" "(engine-plugin-cmdb|cmdb;)"; then
   export GENERATION_USE_CMDB_PLUGIN="${GENERATION_USE_CMDB_PLUGIN:-true}"
 fi
 

--- a/execution/common.sh
+++ b/execution/common.sh
@@ -36,7 +36,7 @@ export GENERATION_LOG_FORMAT="${GENERATION_LOG_FORMAT:-${LOG_FORMAT_COMPACT}}"
 # Determine if using the cmdb plugin
 # Provide an explicit override as well
 # TODO(mfl) remove once migration to the cmdb plugin is complete and proven
-if contains "${GENERATION_PLUGIN_DIRS}" "cmdb"; then
+if contains "${GENERATION_PLUGIN_DIRS}" "engine-plugin-cmdb"; then
   export GENERATION_USE_CMDB_PLUGIN="${GENERATION_USE_CMDB_PLUGIN:-true}"
 fi
 

--- a/execution/common.sh
+++ b/execution/common.sh
@@ -36,7 +36,7 @@ export GENERATION_LOG_FORMAT="${GENERATION_LOG_FORMAT:-${LOG_FORMAT_COMPACT}}"
 # Determine if using the cmdb plugin
 # Provide an explicit override as well
 # TODO(mfl) remove once migration to the cmdb plugin is complete and proven
-if contains "${GENERATION_PLUGIN_DIRS}" "engine-plugin-cmdb"; then
+if contains "${GENERATION_PLUGIN_DIRS}" "(engine-plugin-cmdb|cmdb;)"; then
   export GENERATION_USE_CMDB_PLUGIN="${GENERATION_USE_CMDB_PLUGIN:-true}"
 fi
 


### PR DESCRIPTION
## Intent of Change
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
Make the token used to detect use of the cmdb plugin more specific so directory names containing `cmdb` don't result in a false positive.

## Motivation and Context
No surprises - don't trigger the dynamic cmdb behaviour unless it is really required.

## How Has This Been Tested?
Local template generation

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

