### PR TITLE
feat: set SES active ruleset function

### DIFF
--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -3015,3 +3015,11 @@ function get_image_from_container_registry() {
   fi
 
 }
+
+# SES Rule Set Activation
+function setActiveSESRuleSet {
+  local region="$1"; shift
+  local ruleset_name="$1"; shift
+
+  aws --region "${region}"  set-active-receipt-rule-set --rule-set-name "{ruleset_name}"
+}


### PR DESCRIPTION
## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
Add function to set the inbound SES active ruleset.

## Motivation and Context
This action can only be done via CLI. It is needed to integrate with the account level inbound SES support.

## How Has This Been Tested?
Local template generation.

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
- Account inbound SES configuration - 

### Consumer Actions:
- None

