### PR TITLE
feat: add check for aws account usage

### DIFF
--- a/execution/setCredentials.sh
+++ b/execution/setCredentials.sh
@@ -39,8 +39,9 @@ if [[ "${ACCOUNT_PROVIDER}" == 'aws' ]]; then
         fi
     fi
 
+    profile_account="$(aws sts get-caller-identity --query 'Account' --output text)"
+
     if [[ -n "${PROVIDERID}" ]]; then
-        profile_account="$(aws sts get-caller-identity --query 'Account' --output text)"
         if [[ "${profile_account}" != "${PROVIDERID:-$AID}" ]]; then
             if [[ -n "${AWS_DEFAULT_PROFILE}" ]]; then
                 fatal "The aws config profile ${AWS_DEFAULT_PROFILE} doesn't provide access to the account requested - ${ACCOUNT} ${PROVIDERID}"

--- a/execution/setCredentials.sh
+++ b/execution/setCredentials.sh
@@ -2,38 +2,53 @@
 
 # Set up credentials to interact with cloud providers when running engine processes
 
-# Set default AWS credentials if available (hook from Jenkins framework)
-CHECK_AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-${ACCOUNT_TEMP_AWS_ACCESS_KEY_ID}}"
-[[ -n "${ACCOUNT_AWS_ACCESS_KEY_ID_VAR}" ]] && CHECK_AWS_ACCESS_KEY_ID="${CHECK_AWS_ACCESS_KEY_ID:-${!ACCOUNT_AWS_ACCESS_KEY_ID_VAR}}"
-[[ -n "${CHECK_AWS_ACCESS_KEY_ID}" ]] && export AWS_ACCESS_KEY_ID="${CHECK_AWS_ACCESS_KEY_ID}"
+if [[ "${ACCOUNT_PROVIDER}" == 'aws' ]]; then
+    # Set default AWS credentials if available (hook from Jenkins framework)
+    CHECK_AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-${ACCOUNT_TEMP_AWS_ACCESS_KEY_ID}}"
+    [[ -n "${ACCOUNT_AWS_ACCESS_KEY_ID_VAR}" ]] && CHECK_AWS_ACCESS_KEY_ID="${CHECK_AWS_ACCESS_KEY_ID:-${!ACCOUNT_AWS_ACCESS_KEY_ID_VAR}}"
+    [[ -n "${CHECK_AWS_ACCESS_KEY_ID}" ]] && export AWS_ACCESS_KEY_ID="${CHECK_AWS_ACCESS_KEY_ID}"
 
-CHECK_AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-${ACCOUNT_TEMP_AWS_SECRET_ACCESS_KEY}}"
-[[ -n "${ACCOUNT_AWS_SECRET_ACCESS_KEY_VAR}" ]] && CHECK_AWS_SECRET_ACCESS_KEY="${CHECK_AWS_SECRET_ACCESS_KEY:-${!ACCOUNT_AWS_SECRET_ACCESS_KEY_VAR}}"
-[[ -n "${CHECK_AWS_SECRET_ACCESS_KEY}" ]] && export AWS_SECRET_ACCESS_KEY="${CHECK_AWS_SECRET_ACCESS_KEY}"
+    CHECK_AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-${ACCOUNT_TEMP_AWS_SECRET_ACCESS_KEY}}"
+    [[ -n "${ACCOUNT_AWS_SECRET_ACCESS_KEY_VAR}" ]] && CHECK_AWS_SECRET_ACCESS_KEY="${CHECK_AWS_SECRET_ACCESS_KEY:-${!ACCOUNT_AWS_SECRET_ACCESS_KEY_VAR}}"
+    [[ -n "${CHECK_AWS_SECRET_ACCESS_KEY}" ]] && export AWS_SECRET_ACCESS_KEY="${CHECK_AWS_SECRET_ACCESS_KEY}"
 
-CHECK_AWS_SESSION_TOKEN="${AWS_SESSION_TOKEN:-${ACCOUNT_TEMP_AWS_SESSION_TOKEN}}"
-if [[ -n "${CHECK_AWS_SESSION_TOKEN}" ]]; then export AWS_SESSION_TOKEN="${CHECK_AWS_SESSION_TOKEN}"; fi
+    CHECK_AWS_SESSION_TOKEN="${AWS_SESSION_TOKEN:-${ACCOUNT_TEMP_AWS_SESSION_TOKEN}}"
+    if [[ -n "${CHECK_AWS_SESSION_TOKEN}" ]]; then export AWS_SESSION_TOKEN="${CHECK_AWS_SESSION_TOKEN}"; fi
 
-# Set the profile for IAM access if AWS credentials not in the environment
-# We would normally redirect to /dev/null but this triggers an "unknown encoding"
-# bug in python
-if [[ ((-z "${AWS_ACCESS_KEY_ID}") || (-z "${AWS_SECRET_ACCESS_KEY}")) ]]; then
-    if [[ -n "${ACCOUNT}" ]]; then
-        aws configure list --profile "${ACCOUNT}" > $(getTempFile "account_profile_status_XXXXXX.txt") 2>&1
-        if [[ $? -eq 0 ]]; then
-            export AWS_DEFAULT_PROFILE="${ACCOUNT}"
+    # Set the profile for IAM access if AWS credentials not in the environment
+    # We would normally redirect to /dev/null but this triggers an "unknown encoding"
+    # bug in python
+    if [[ ((-z "${AWS_ACCESS_KEY_ID}") || (-z "${AWS_SECRET_ACCESS_KEY}")) ]]; then
+        if [[ -n "${ACCOUNT}" ]]; then
+            aws configure list --profile "${ACCOUNT}" > /dev/null 2>&1
+            if [[ $? -eq 0 ]]; then
+                export AWS_DEFAULT_PROFILE="${ACCOUNT}"
+            fi
+        fi
+        if [[ -n "${AID}" ]]; then
+            aws configure list --profile "${AID}" > /dev/null 2>&1
+            if [[ $? -eq 0 ]]; then
+                export AWS_DEFAULT_PROFILE="${AID}"
+            fi
+        fi
+        if [[ -n "${PROVIDERID}" ]]; then
+            aws configure list --profile "${PROVIDERID}" > /dev/null 2>&1
+            if [[ $? -eq 0 ]]; then
+                export AWS_DEFAULT_PROFILE="${PROVIDERID}"
+            fi
         fi
     fi
-    if [[ -n "${AID}" ]]; then
-        aws configure list --profile "${AID}" > $(getTempFile "id_profile_status_XXXXXX.txt") 2>&1
-        if [[ $? -eq 0 ]]; then
-            export AWS_DEFAULT_PROFILE="${AID}"
-        fi
-    fi
-    if [[ $ACCOUNT_PROVIDER == 'aws' ]]; then
-        aws configure list --profile "${PROVIDERID}" > $(getTempFile "awsid_profile_status_XXXXXX.txt") 2>&1
-        if [[ $? -eq 0 ]]; then
-            export AWS_DEFAULT_PROFILE="${PROVIDERID}"
+
+    if [[ -n "${PROVIDERID}" ]]; then
+        profile_account="$(aws sts get-caller-identity --query 'Account' --output text)"
+        if [[ "${profile_account}" != "${PROVIDERID:-$AID}" ]]; then
+            if [[ -n "${AWS_DEFAULT_PROFILE}" ]]; then
+                fatal "The aws config profile ${AWS_DEFAULT_PROFILE} doesn't provide access to the account requested - ${ACCOUNT} ${PROVIDERID}"
+            else
+                fatal "The provided credentials don't provide access to the account requested - ${ACCOUNT} ${PROVIDERID}"
+            fi
+            fatal "Check your aws credentials configuration  and try again"
+            exit 255
         fi
     fi
 fi


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Adds an authenticated call to aws as part of setCredential which returns the account the calling identity belongs to
- Use this return to both initialise authentication early and to also make sure the account matches the account that hamlet is trying to use

## Motivation and Context

primary motivation is https://github.com/hamlet-io/executor-bash/issues/200 which raised an issue with deployments being triggered in wrong accounts if an MFA token is entered wrong or an aws config profile is missing

## How Has This Been Tested?

Tested locally

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

