### PR TITLE
feat: .cmdb directory

### DIFF
--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -461,7 +461,8 @@ function process_template_pass() {
   # Make the temp directory a cmdb so that we can write into it
   args+=("-r" "outputDir=${tmp_dir}")
   args+=("-g" "${tmp_dir}")
-  echo '{}' > "${tmp_dir}/.cmdb"
+  mkdir "${tmp_dir}/.cmdb"
+  echo '{}' > "${tmp_dir}/.cmdb/config.json"
 
   # Setup log outputs
   local generation_log_file_name="${output_filename}.generation-log.json"

--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -459,10 +459,13 @@ function process_template_pass() {
   fi
 
   # Make the temp directory a cmdb so that we can write into it
+  # Handle multiple passes using the same temporary directory
   args+=("-r" "outputDir=${tmp_dir}")
   args+=("-g" "${tmp_dir}")
-  mkdir "${tmp_dir}/.cmdb"
-  echo '{}' > "${tmp_dir}/.cmdb/config.json"
+  if [[ ! -f "${tmp_dir}/.cmdb/config.json" ]]; then
+    mkdir "${tmp_dir}/.cmdb"
+    echo '{}' > "${tmp_dir}/.cmdb/config.json"
+  fi
 
   # Setup log outputs
   local generation_log_file_name="${output_filename}.generation-log.json"

--- a/execution/contextTree.sh
+++ b/execution/contextTree.sh
@@ -1699,7 +1699,13 @@ function process_cmdb() {
     local cmdb_repo="$(filePath "${cmdb_git_repo}")"
     debug "Checking repo ${cmdb_repo} ..."
 
+    # Support .cmdb as a directory or a file
     local cmdb_version_file="${cmdb_repo}/.cmdb"
+    if [[ ! -f "${cmdb_version_file}" ]]; then
+      local cmdb_version_file="${cmdb_repo}/.cmdb/config.json"
+      mkdir -p "${cmdb_repo}/.cmdb"
+    fi
+
     local current_version=""
     local pin_version=""
 

--- a/execution/freemarker.sh
+++ b/execution/freemarker.sh
@@ -19,7 +19,7 @@ where
 (o) -c CMDB           cmdb to be included
 (m) -d TEMPLATEDIR    is a directory containing templates
 (o) -g CMDB=PATH      defines a cmdb and the corresponding path
-(o) -g PATH           finds all cmdbs under PATH based on a .cmdb marker file
+(o) -g PATH           finds all cmdbs under PATH based on a .cmdb marker file or directory
     -h                shows this text
 (o) -l LOGLEVEL       required log level
 (m) -o OUTPUT         is the path of the resulting document
@@ -38,7 +38,7 @@ NOTES:
 3. Values containing spaces need to be quoted to ensure they are passed in as a single argument
 4. -r and -v are equivalent except that -r will not check if the provided value
    is a valid filename
-5. For a cmdb located via a .cmdb marker file, cmdb name = the containing directory name
+5. For a cmdb located via a .cmdb marker file or directory, cmdb name = the containing directory name
 
 EOF
     exit


### PR DESCRIPTION
## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
Convert the .cmdb marker file to a directory to permit it to capture migration logs. The previous contents move to `config.json` within the directory.

## Motivation and Context
Capture migration logs in the repo.
 
## How Has This Been Tested?
Local migration runs

### Prerequisite PRs:
- https://github.com/hamlet-io/executor-bash/pull/235

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

