### PR TITLE
feat: Hamletcli automation provider

### DIFF
--- a/automation/common.sh
+++ b/automation/common.sh
@@ -73,7 +73,7 @@ function save_context_property() {
   fi
 
   case "${AUTOMATION_PROVIDER}" in
-    jenkins)
+    jenkins|hamletcli)
       echo "${name}=${property_value}" >> "${file}"
       ;;
     azurepipelines)

--- a/automation/constructTree.sh
+++ b/automation/constructTree.sh
@@ -325,7 +325,7 @@ if [[ "${USE_EXISITNG_TREE}" == "false" ]]; then
 fi
 
 if [[ "${USE_EXISTING_TREE}" == "true" ]]; then
-    if [[ -n "${ROOT_DIR}" && -d "${ROOT_DIR}" ]]; then
+    if [[ -z "${ROOT_DIR}" || ! (-d "${ROOT_DIR}") ]]; then
         fatal "ROOT_DIR: ${ROOT_DIR} - could not be found for existing tree"
         exit
     fi

--- a/automation/constructTree.sh
+++ b/automation/constructTree.sh
@@ -21,13 +21,14 @@ Usage: $(basename $0)
 
 where
 
-(o) -a                                  if the account directories should not be included
-(o) -c PRODUCT_CONFIG_REFERENCE                 is the git reference for the config repo
-    -h                                  shows this text
-(o) -i PRODUCT_INFRASTRUCTURE_REFERENCE         is the git reference for the config repo
-(o) -r                                  if the product directories should not be included
-(o) -x ACCOUNT_CONFIG_REFERENCE         is the git ref for the acccount config repo
-(o) -y ACCOUNT_INFRASTRUCTURE_REFERENCE is the git ref for the acccount infrastructure repo
+(o) -a                                      if the account directories should not be included
+(o) -c PRODUCT_CONFIG_REFERENCE             is the git reference for the config repo
+(o) -e USE_EXISTING_TREE                    use an existing CMDB tree
+    -h                                      shows this text
+(o) -i PRODUCT_INFRASTRUCTURE_REFERENCE     is the git reference for the config repo
+(o) -r                                      if the product directories should not be included
+(o) -x ACCOUNT_CONFIG_REFERENCE             is the git ref for the acccount config repo
+(o) -y ACCOUNT_INFRASTRUCTURE_REFERENCE     is the git ref for the acccount infrastructure repo
 (m) mandatory, (o) optional, (d) deprecated
 
 DEFAULTS:
@@ -46,13 +47,16 @@ EOF
 }
 
 # Parse options
-while getopts ":ac:hi:rx:" opt; do
+while getopts ":ac:ef:hi:rx:" opt; do
     case $opt in
         a)
             EXCLUDE_ACCOUNT_DIRECTORIES="true"
             ;;
         c)
             PRODUCT_CONFIG_REFERENCE="${OPTARG}"
+            ;;
+        e)
+            USE_EXISTING_TREE="true"
             ;;
         h)
             usage
@@ -85,235 +89,247 @@ ACCOUNT_CONFIG_REFERENCE="${ACCOUNT_CONFIG_REFERENCE:-$ACCOUNT_CONFIG_REFERENCE_
 ACCOUNT_INFRASTRUCTURE_REFERENCE="${ACCOUNT_INFRASTRUCTURE_REFERENCE:-$ACCOUNT_INFRASTRUCTURE_REFERENCE_DEFAULT}"
 EXCLUDE_ACCOUNT_DIRECTORIES="${EXCLUDE_ACCOUNT_DIRECTORIES:-false}"
 EXCLUDE_PRODUCT_DIRECTORIES="${EXCLUDE_PRODUCT_DIRECTORIES:-false}"
+USE_EXISTING_TREE="${USE_EXISTING_TREE:-false}"
 
 # Check for required context
 [[ -z "${ACCOUNT}" ]] && fatal "ACCOUNT not defined" && exit
 
-# Save for later steps
-save_context_property PRODUCT_CONFIG_REFERENCE "${PRODUCT_CONFIG_REFERENCE}"
-save_context_property PRODUCT_INFRASTRUCTURE_REFERENCE "${PRODUCT_INFRASTRUCTURE_REFERENCE}"
-save_context_property ACCOUNT_CONFIG_REFERENCE "${ACCOUNT_CONFIG_REFERENCE}"
-save_context_property ACCOUNT_INFRASTRUCTURE_REFERENCE "${ACCOUNT_INFRASTRUCTURE_REFERENCE}"
+if [[ "${USE_EXISITNG_TREE}" == "false" ]]; then
 
-# Record what is happening
-info "Creating the context directory tree"
+    # Save for later steps
+    save_context_property PRODUCT_CONFIG_REFERENCE "${PRODUCT_CONFIG_REFERENCE}"
+    save_context_property PRODUCT_INFRASTRUCTURE_REFERENCE "${PRODUCT_INFRASTRUCTURE_REFERENCE}"
+    save_context_property ACCOUNT_CONFIG_REFERENCE "${ACCOUNT_CONFIG_REFERENCE}"
+    save_context_property ACCOUNT_INFRASTRUCTURE_REFERENCE "${ACCOUNT_INFRASTRUCTURE_REFERENCE}"
 
-# Define the top level directory representing the account
-BASE_DIR="${AUTOMATION_DATA_DIR}/${ACCOUNT}"
-mkdir -p "${BASE_DIR}"
-touch ${BASE_DIR}/root.json
+    # Record what is happening
+    info "Creating the context directory tree"
 
-# Pull repos into a temporary directory so the contents can be examined
-BASE_DIR_TEMP="${BASE_DIR}/temp"
+    # Define the top level directory representing the account
+    BASE_DIR="${AUTOMATION_DATA_DIR}/${ACCOUNT}"
+    mkdir -p "${BASE_DIR}"
+    touch ${BASE_DIR}/root.json
 
-if [[ !("${EXCLUDE_PRODUCT_DIRECTORIES}" == "true") ]]; then
+    # Pull repos into a temporary directory so the contents can be examined
+    BASE_DIR_TEMP="${BASE_DIR}/temp"
 
-    # Multiple products in the product config repo
-    MULTI_PRODUCT_REPO=false
+    if [[ !("${EXCLUDE_PRODUCT_DIRECTORIES}" == "true") ]]; then
 
-    # Pull in the product config repo
-    ${AUTOMATION_DIR}/manageRepo.sh -c -l "product config" \
-        -n "${PRODUCT_CONFIG_REPO}" -v "${PRODUCT_GIT_PROVIDER}" \
-        -d "${BASE_DIR_TEMP}" -b "${PRODUCT_CONFIG_REFERENCE}"
-    RESULT=$? && [[ ${RESULT} -ne 0 ]] && exit
+        # Multiple products in the product config repo
+        MULTI_PRODUCT_REPO=false
 
-    # Ensure temporary files are ignored
-    [[ (! -f "${BASE_DIR_TEMP}/.gitignore") || ($(grep -q "temp_\*" "${BASE_DIR_TEMP}/.gitignore") -ne 0) ]] && \
-      echo "temp_*" >> "${BASE_DIR_TEMP}/.gitignore"
-
-    # The config repo may contain
-    # - config +/- infrastructure
-    # - product(s) +/- account(s)
-    if [[ -n $(findDir "${BASE_DIR_TEMP}" "infrastructure") ]]; then
-        # Mix of infrastructure and config
-        ACCOUNT_CANDIDATE_DIR="$(findDir "${BASE_DIR_TEMP}" "${ACCOUNT}")"
-        # Ensure we definitely have an account
-        if [[ ( -n "${ACCOUNT_CANDIDATE_DIR}" ) &&
-                (
-                    ( -d "${ACCOUNT_CANDIDATE_DIR}/account.json" ) ||
-                    ( -d "${ACCOUNT_CANDIDATE_DIR}/config/account.json" )
-                ) ]]; then
-            # Everything in one repo
-            PRODUCT_CONFIG_DIR="${BASE_DIR}/cmdb"
-        else
-            PRODUCT_CANDIDATE_DIR="$(findDir "${BASE_DIR_TEMP}" "${PRODUCT}")"
-            # Ensure we definitely have a product
-            if [[ ( -n "${PRODUCT_CANDIDATE_DIR}" ) &&
-                  (
-                      ( -d "${PRODUCT_CANDIDATE_DIR}/product.json" ) ||
-                      ( -d "${PRODUCT_CANDIDATE_DIR}/config/product.json" )
-                  ) ]]; then
-                # Multi-product repo
-                PRODUCT_CONFIG_DIR="${BASE_DIR}/products"
-                MULTI_PRODUCT_REPO=true
-            else
-                # Single product repo
-                PRODUCT_CONFIG_DIR="${BASE_DIR}/${PRODUCT}"
-            fi
-        fi
-    else
-        # Just config
-        ACCOUNT_CANDIDATE_DIR="$(findDir "${BASE_DIR_TEMP}" "${ACCOUNT}")"
-        # Ensure we definitely have an account
-        if [[ ( -n "${ACCOUNT_CANDIDATE_DIR}" ) &&
-                (
-                    ( -d "${ACCOUNT_CANDIDATE_DIR}/account.json" ) ||
-                    ( -d "${ACCOUNT_CANDIDATE_DIR}/config/account.json" )
-                ) ]]; then
-            # products and accounts
-            PRODUCT_CONFIG_DIR="${BASE_DIR}/config"
-        else
-            PRODUCT_CANDIDATE_DIR="$(findDir "${BASE_DIR_TEMP}" "${PRODUCT}")"
-            # Ensure we definitely have a product
-            if [[ ( -n "${PRODUCT_CANDIDATE_DIR}" ) &&
-                  (
-                      ( -d "${PRODUCT_CANDIDATE_DIR}/product.json" ) ||
-                      ( -d "${PRODUCT_CANDIDATE_DIR}/config/product.json" )
-                  ) ]]; then
-                # Multi-product repo
-                PRODUCT_CONFIG_DIR="${BASE_DIR}/config/products"
-                MULTI_PRODUCT_REPO=true
-            else
-                # Single product repo
-                PRODUCT_CONFIG_DIR="${BASE_DIR}/config/${PRODUCT}"
-            fi
-        fi
-    fi
-
-    mkdir -p $(filePath "${PRODUCT_CONFIG_DIR}")
-    mv "${BASE_DIR_TEMP}" "${PRODUCT_CONFIG_DIR}"
-    save_context_property PRODUCT_CONFIG_COMMIT "$(git -C "${PRODUCT_CONFIG_DIR}" rev-parse HEAD)"
-
-    PRODUCT_INFRASTRUCTURE_DIR=$(findGen3ProductInfrastructureDir "${BASE_DIR}" "${PRODUCT}")
-    if [[ -z "${PRODUCT_INFRASTRUCTURE_DIR}" ]]; then
-        # Pull in the infrastructure repo
-        ${AUTOMATION_DIR}/manageRepo.sh -c -l "product infrastructure" \
-            -n "${PRODUCT_INFRASTRUCTURE_REPO}" -v "${PRODUCT_GIT_PROVIDER}" \
-            -d "${BASE_DIR_TEMP}" -b "${PRODUCT_INFRASTRUCTURE_REFERENCE}"
+        # Pull in the product config repo
+        ${AUTOMATION_DIR}/manageRepo.sh -c -l "product config" \
+            -n "${PRODUCT_CONFIG_REPO}" -v "${PRODUCT_GIT_PROVIDER}" \
+            -d "${BASE_DIR_TEMP}" -b "${PRODUCT_CONFIG_REFERENCE}"
         RESULT=$? && [[ ${RESULT} -ne 0 ]] && exit
 
         # Ensure temporary files are ignored
         [[ (! -f "${BASE_DIR_TEMP}/.gitignore") || ($(grep -q "temp_\*" "${BASE_DIR_TEMP}/.gitignore") -ne 0) ]] && \
-          echo "temp_*" >> "${BASE_DIR_TEMP}/.gitignore"
+        echo "temp_*" >> "${BASE_DIR_TEMP}/.gitignore"
 
-        ACCOUNT_CANDIDATE_DIR="$(findDir "${BASE_DIR_TEMP}" "${ACCOUNT}")"
-        # Ensure we definitely have an account
-        if [[ ( -n "${ACCOUNT_CANDIDATE_DIR}" ) &&
-                (
-                    ( -d "${ACCOUNT_CANDIDATE_DIR}/account.json" ) ||
-                    ( -d "${ACCOUNT_CANDIDATE_DIR}/config/account.json" )
-                ) ]]; then
-            # products and accounts
-            PRODUCT_INFRASTRUCTURE_DIR="${BASE_DIR}/infrastructure"
-        else
-            # Is product repo contains multiple products, assume the infrastructure repo does too
-            if [[ "${MULTI_PRODUCT_REPO}" == "true" ]]; then
-                # Multi-product repo
-                PRODUCT_INFRASTRUCTURE_DIR="${BASE_DIR}/infrastructure/products"
-            else
-                # Single product repo
-                PRODUCT_INFRASTRUCTURE_DIR="${BASE_DIR}/infrastructure/${PRODUCT}"
-            fi
-        fi
-        mkdir -p $(filePath "${PRODUCT_INFRASTRUCTURE_DIR}")
-        mv "${BASE_DIR_TEMP}" "${PRODUCT_INFRASTRUCTURE_DIR}"
-    fi
-
-    save_context_property PRODUCT_INFRASTRUCTURE_COMMIT "$(git -C "${PRODUCT_INFRASTRUCTURE_DIR}" rev-parse HEAD)"
-fi
-
-if [[ !("${EXCLUDE_ACCOUNT_DIRECTORIES}" == "true") ]]; then
-
-    # Multiple accounts in the account config repo
-    MULTI_ACCOUNT_REPO=false
-
-    # Pull in the account config repo
-    ACCOUNT_CONFIG_DIR=$(findGen3AccountDir "${BASE_DIR}" "${ACCOUNT}")
-    if [[ -z "${ACCOUNT_CONFIG_DIR}" ]]; then
-        ${AUTOMATION_DIR}/manageRepo.sh -c -l "account config" \
-            -n "${ACCOUNT_CONFIG_REPO}" -v "${ACCOUNT_GIT_PROVIDER}" \
-            -d "${BASE_DIR_TEMP}" -b "${ACCOUNT_CONFIG_REFERENCE}"
-        RESULT=$? && [[ ${RESULT} -ne 0 ]] && exit
-
-        # Ensure temporary files are ignored
-        [[ (! -f "${BASE_DIR_TEMP}/.gitignore") || ($(grep -q "temp_\*" "${BASE_DIR_TEMP}/.gitignore") -ne 0) ]] && \
-          echo "temp_*" >> "${BASE_DIR_TEMP}/.gitignore"
-
+        # The config repo may contain
+        # - config +/- infrastructure
+        # - product(s) +/- account(s)
         if [[ -n $(findDir "${BASE_DIR_TEMP}" "infrastructure") ]]; then
             # Mix of infrastructure and config
             ACCOUNT_CANDIDATE_DIR="$(findDir "${BASE_DIR_TEMP}" "${ACCOUNT}")"
             # Ensure we definitely have an account
             if [[ ( -n "${ACCOUNT_CANDIDATE_DIR}" ) &&
-                  (
-                      ( -d "${ACCOUNT_CANDIDATE_DIR}/account.json" ) ||
-                      ( -d "${ACCOUNT_CANDIDATE_DIR}/config/account.json" )
-                  ) ]]; then
-                # Multi-account repo
-                ACCOUNT_CONFIG_DIR="${BASE_DIR}/accounts"
-                MULTI_ACCOUNT_REPO=true
+                    (
+                        ( -d "${ACCOUNT_CANDIDATE_DIR}/account.json" ) ||
+                        ( -d "${ACCOUNT_CANDIDATE_DIR}/config/account.json" )
+                    ) ]]; then
+                # Everything in one repo
+                PRODUCT_CONFIG_DIR="${BASE_DIR}/cmdb"
             else
-                # Single account repo
-                ACCOUNT_CONFIG_DIR="${BASE_DIR}/${ACCOUNT}"
+                PRODUCT_CANDIDATE_DIR="$(findDir "${BASE_DIR_TEMP}" "${PRODUCT}")"
+                # Ensure we definitely have a product
+                if [[ ( -n "${PRODUCT_CANDIDATE_DIR}" ) &&
+                    (
+                        ( -d "${PRODUCT_CANDIDATE_DIR}/product.json" ) ||
+                        ( -d "${PRODUCT_CANDIDATE_DIR}/config/product.json" )
+                    ) ]]; then
+                    # Multi-product repo
+                    PRODUCT_CONFIG_DIR="${BASE_DIR}/products"
+                    MULTI_PRODUCT_REPO=true
+                else
+                    # Single product repo
+                    PRODUCT_CONFIG_DIR="${BASE_DIR}/${PRODUCT}"
+                fi
             fi
         else
+            # Just config
             ACCOUNT_CANDIDATE_DIR="$(findDir "${BASE_DIR_TEMP}" "${ACCOUNT}")"
             # Ensure we definitely have an account
             if [[ ( -n "${ACCOUNT_CANDIDATE_DIR}" ) &&
-                  (
-                      ( -d "${ACCOUNT_CANDIDATE_DIR}/account.json" ) ||
-                      ( -d "${ACCOUNT_CANDIDATE_DIR}/config/account.json" )
-                  ) ]]; then
-                # Multi-account repo
-                ACCOUNT_CONFIG_DIR="${BASE_DIR}/config/accounts"
-                MULTI_ACCOUNT_REPO=true
+                    (
+                        ( -d "${ACCOUNT_CANDIDATE_DIR}/account.json" ) ||
+                        ( -d "${ACCOUNT_CANDIDATE_DIR}/config/account.json" )
+                    ) ]]; then
+                # products and accounts
+                PRODUCT_CONFIG_DIR="${BASE_DIR}/config"
             else
-                # Single account repo
-                ACCOUNT_CONFIG_DIR="${BASE_DIR}/config/${ACCOUNT}"
+                PRODUCT_CANDIDATE_DIR="$(findDir "${BASE_DIR_TEMP}" "${PRODUCT}")"
+                # Ensure we definitely have a product
+                if [[ ( -n "${PRODUCT_CANDIDATE_DIR}" ) &&
+                    (
+                        ( -d "${PRODUCT_CANDIDATE_DIR}/product.json" ) ||
+                        ( -d "${PRODUCT_CANDIDATE_DIR}/config/product.json" )
+                    ) ]]; then
+                    # Multi-product repo
+                    PRODUCT_CONFIG_DIR="${BASE_DIR}/config/products"
+                    MULTI_PRODUCT_REPO=true
+                else
+                    # Single product repo
+                    PRODUCT_CONFIG_DIR="${BASE_DIR}/config/${PRODUCT}"
+                fi
             fi
         fi
-        mkdir -p $(filePath "${ACCOUNT_CONFIG_DIR}")
-        mv "${BASE_DIR_TEMP}" "${ACCOUNT_CONFIG_DIR}"
-        save_context_property ACCOUNT_CONFIG_COMMIT "$(git -C "${ACCOUNT_CONFIG_DIR}" rev-parse HEAD)"
-    fi
 
-    ACCOUNT_INFRASTRUCTURE_DIR=$(findGen3AccountInfrastructureDir "${BASE_DIR}" "${ACCOUNT}")
-    if [[ -z "${ACCOUNT_INFRASTRUCTURE_DIR}" ]]; then
-        # Pull in the account infrastructure repo
-        ${AUTOMATION_DIR}/manageRepo.sh -c -l "account infrastructure" \
-            -n "${ACCOUNT_INFRASTRUCTURE_REPO}" -v "${ACCOUNT_GIT_PROVIDER}" \
-            -d "${BASE_DIR_TEMP}" -b "${ACCOUNT_INFRASTRUCTURE_REFERENCE}"
-        RESULT=$? && [[ ${RESULT} -ne 0 ]] && exit
+        mkdir -p $(filePath "${PRODUCT_CONFIG_DIR}")
+        mv "${BASE_DIR_TEMP}" "${PRODUCT_CONFIG_DIR}"
+        save_context_property PRODUCT_CONFIG_COMMIT "$(git -C "${PRODUCT_CONFIG_DIR}" rev-parse HEAD)"
 
-        # Ensure temporary files are ignored
-        [[ (! -f "${BASE_DIR_TEMP}/.gitignore") || ($(grep -q "temp_\*" "${BASE_DIR_TEMP}/.gitignore") -ne 0) ]] && \
-          echo "temp_*" >> "${BASE_DIR_TEMP}/.gitignore"
+        PRODUCT_INFRASTRUCTURE_DIR=$(findGen3ProductInfrastructureDir "${BASE_DIR}" "${PRODUCT}")
+        if [[ -z "${PRODUCT_INFRASTRUCTURE_DIR}" ]]; then
+            # Pull in the infrastructure repo
+            ${AUTOMATION_DIR}/manageRepo.sh -c -l "product infrastructure" \
+                -n "${PRODUCT_INFRASTRUCTURE_REPO}" -v "${PRODUCT_GIT_PROVIDER}" \
+                -d "${BASE_DIR_TEMP}" -b "${PRODUCT_INFRASTRUCTURE_REFERENCE}"
+            RESULT=$? && [[ ${RESULT} -ne 0 ]] && exit
 
-        # Is account repo contains multiple accounts, assume the infrastructure repo does too
-        if [[ "${MULTI_ACCOUNT_REPO}" == "true" ]]; then
-            # Multi-account repo
-            ACCOUNT_INFRASTRUCTURE_DIR="${BASE_DIR}/infrastructure/accounts"
-        else
-            # Single account repo
-            ACCOUNT_INFRASTRUCTURE_DIR="${BASE_DIR}/infrastructure/${ACCOUNT}"
+            # Ensure temporary files are ignored
+            [[ (! -f "${BASE_DIR_TEMP}/.gitignore") || ($(grep -q "temp_\*" "${BASE_DIR_TEMP}/.gitignore") -ne 0) ]] && \
+            echo "temp_*" >> "${BASE_DIR_TEMP}/.gitignore"
+
+            ACCOUNT_CANDIDATE_DIR="$(findDir "${BASE_DIR_TEMP}" "${ACCOUNT}")"
+            # Ensure we definitely have an account
+            if [[ ( -n "${ACCOUNT_CANDIDATE_DIR}" ) &&
+                    (
+                        ( -d "${ACCOUNT_CANDIDATE_DIR}/account.json" ) ||
+                        ( -d "${ACCOUNT_CANDIDATE_DIR}/config/account.json" )
+                    ) ]]; then
+                # products and accounts
+                PRODUCT_INFRASTRUCTURE_DIR="${BASE_DIR}/infrastructure"
+            else
+                # Is product repo contains multiple products, assume the infrastructure repo does too
+                if [[ "${MULTI_PRODUCT_REPO}" == "true" ]]; then
+                    # Multi-product repo
+                    PRODUCT_INFRASTRUCTURE_DIR="${BASE_DIR}/infrastructure/products"
+                else
+                    # Single product repo
+                    PRODUCT_INFRASTRUCTURE_DIR="${BASE_DIR}/infrastructure/${PRODUCT}"
+                fi
+            fi
+            mkdir -p $(filePath "${PRODUCT_INFRASTRUCTURE_DIR}")
+            mv "${BASE_DIR_TEMP}" "${PRODUCT_INFRASTRUCTURE_DIR}"
         fi
-        mkdir -p $(filePath "${ACCOUNT_INFRASTRUCTURE_DIR}")
-        mv "${BASE_DIR_TEMP}" "${ACCOUNT_INFRASTRUCTURE_DIR}"
+
+        save_context_property PRODUCT_INFRASTRUCTURE_COMMIT "$(git -C "${PRODUCT_INFRASTRUCTURE_DIR}" rev-parse HEAD)"
     fi
 
-# TODO(mfl): 03/02/2020 Remove the following code once its confirmed its redundant
-# From the Jenkins logs it throws errors when TENANT is non-empty which makes sense
-# as BASE_DIR_TEMP has been cleared by processing of the ACCOUNT. However sometimes
-# it doesn't which suggests that it either is blank or contains a directory with an
-# infrastructure subdirectory.
-# Either way, without a temp dir to move, it seems unnecessary.
-#    TENANT_INFRASTRUCTURE_DIR=$(findGen3TenantInfrastructureDir "${BASE_DIR}" "${TENANT}")
-#    if [[ -z "${TENANT_INFRASTRUCTURE_DIR}" ]]; then
-#
-#        TENANT_INFRASTRUCTURE_DIR="${BASE_DIR}/${TENANT}"
-#        mkdir -p $(filePath "${TENANT_INFRASTRUCTURE_DIR}")
-#        mv "${BASE_DIR_TEMP}" "${TENANT_INFRASTRUCTURE_DIR}"
-#    fi
+    if [[ !("${EXCLUDE_ACCOUNT_DIRECTORIES}" == "true") ]]; then
 
+        # Multiple accounts in the account config repo
+        MULTI_ACCOUNT_REPO=false
+
+        # Pull in the account config repo
+        ACCOUNT_CONFIG_DIR=$(findGen3AccountDir "${BASE_DIR}" "${ACCOUNT}")
+        if [[ -z "${ACCOUNT_CONFIG_DIR}" ]]; then
+            ${AUTOMATION_DIR}/manageRepo.sh -c -l "account config" \
+                -n "${ACCOUNT_CONFIG_REPO}" -v "${ACCOUNT_GIT_PROVIDER}" \
+                -d "${BASE_DIR_TEMP}" -b "${ACCOUNT_CONFIG_REFERENCE}"
+            RESULT=$? && [[ ${RESULT} -ne 0 ]] && exit
+
+            # Ensure temporary files are ignored
+            [[ (! -f "${BASE_DIR_TEMP}/.gitignore") || ($(grep -q "temp_\*" "${BASE_DIR_TEMP}/.gitignore") -ne 0) ]] && \
+            echo "temp_*" >> "${BASE_DIR_TEMP}/.gitignore"
+
+            if [[ -n $(findDir "${BASE_DIR_TEMP}" "infrastructure") ]]; then
+                # Mix of infrastructure and config
+                ACCOUNT_CANDIDATE_DIR="$(findDir "${BASE_DIR_TEMP}" "${ACCOUNT}")"
+                # Ensure we definitely have an account
+                if [[ ( -n "${ACCOUNT_CANDIDATE_DIR}" ) &&
+                    (
+                        ( -d "${ACCOUNT_CANDIDATE_DIR}/account.json" ) ||
+                        ( -d "${ACCOUNT_CANDIDATE_DIR}/config/account.json" )
+                    ) ]]; then
+                    # Multi-account repo
+                    ACCOUNT_CONFIG_DIR="${BASE_DIR}/accounts"
+                    MULTI_ACCOUNT_REPO=true
+                else
+                    # Single account repo
+                    ACCOUNT_CONFIG_DIR="${BASE_DIR}/${ACCOUNT}"
+                fi
+            else
+                ACCOUNT_CANDIDATE_DIR="$(findDir "${BASE_DIR_TEMP}" "${ACCOUNT}")"
+                # Ensure we definitely have an account
+                if [[ ( -n "${ACCOUNT_CANDIDATE_DIR}" ) &&
+                    (
+                        ( -d "${ACCOUNT_CANDIDATE_DIR}/account.json" ) ||
+                        ( -d "${ACCOUNT_CANDIDATE_DIR}/config/account.json" )
+                    ) ]]; then
+                    # Multi-account repo
+                    ACCOUNT_CONFIG_DIR="${BASE_DIR}/config/accounts"
+                    MULTI_ACCOUNT_REPO=true
+                else
+                    # Single account repo
+                    ACCOUNT_CONFIG_DIR="${BASE_DIR}/config/${ACCOUNT}"
+                fi
+            fi
+            mkdir -p $(filePath "${ACCOUNT_CONFIG_DIR}")
+            mv "${BASE_DIR_TEMP}" "${ACCOUNT_CONFIG_DIR}"
+            save_context_property ACCOUNT_CONFIG_COMMIT "$(git -C "${ACCOUNT_CONFIG_DIR}" rev-parse HEAD)"
+        fi
+
+        ACCOUNT_INFRASTRUCTURE_DIR=$(findGen3AccountInfrastructureDir "${BASE_DIR}" "${ACCOUNT}")
+        if [[ -z "${ACCOUNT_INFRASTRUCTURE_DIR}" ]]; then
+            # Pull in the account infrastructure repo
+            ${AUTOMATION_DIR}/manageRepo.sh -c -l "account infrastructure" \
+                -n "${ACCOUNT_INFRASTRUCTURE_REPO}" -v "${ACCOUNT_GIT_PROVIDER}" \
+                -d "${BASE_DIR_TEMP}" -b "${ACCOUNT_INFRASTRUCTURE_REFERENCE}"
+            RESULT=$? && [[ ${RESULT} -ne 0 ]] && exit
+
+            # Ensure temporary files are ignored
+            [[ (! -f "${BASE_DIR_TEMP}/.gitignore") || ($(grep -q "temp_\*" "${BASE_DIR_TEMP}/.gitignore") -ne 0) ]] && \
+            echo "temp_*" >> "${BASE_DIR_TEMP}/.gitignore"
+
+            # Is account repo contains multiple accounts, assume the infrastructure repo does too
+            if [[ "${MULTI_ACCOUNT_REPO}" == "true" ]]; then
+                # Multi-account repo
+                ACCOUNT_INFRASTRUCTURE_DIR="${BASE_DIR}/infrastructure/accounts"
+            else
+                # Single account repo
+                ACCOUNT_INFRASTRUCTURE_DIR="${BASE_DIR}/infrastructure/${ACCOUNT}"
+            fi
+            mkdir -p $(filePath "${ACCOUNT_INFRASTRUCTURE_DIR}")
+            mv "${BASE_DIR_TEMP}" "${ACCOUNT_INFRASTRUCTURE_DIR}"
+        fi
+
+    # TODO(mfl): 03/02/2020 Remove the following code once its confirmed its redundant
+    # From the Jenkins logs it throws errors when TENANT is non-empty which makes sense
+    # as BASE_DIR_TEMP has been cleared by processing of the ACCOUNT. However sometimes
+    # it doesn't which suggests that it either is blank or contains a directory with an
+    # infrastructure subdirectory.
+    # Either way, without a temp dir to move, it seems unnecessary.
+    #    TENANT_INFRASTRUCTURE_DIR=$(findGen3TenantInfrastructureDir "${BASE_DIR}" "${TENANT}")
+    #    if [[ -z "${TENANT_INFRASTRUCTURE_DIR}" ]]; then
+    #
+    #        TENANT_INFRASTRUCTURE_DIR="${BASE_DIR}/${TENANT}"
+    #        mkdir -p $(filePath "${TENANT_INFRASTRUCTURE_DIR}")
+    #        mv "${BASE_DIR_TEMP}" "${TENANT_INFRASTRUCTURE_DIR}"
+    #    fi
+
+    fi
+fi
+
+if [[ "${USE_EXISTING_TREE}" == "true" ]]; then
+    if [[ -n "${ROOT_DIR}" && -d "${ROOT_DIR}" ]]; then
+        fatal "ROOT_DIR: ${ROOT_DIR} - could not be found for exsting tree"
+        exit
+    fi
+    BASE_DIR="${ROOT_DIR}"
 fi
 
 # Examine the structure and define key directories

--- a/automation/constructTree.sh
+++ b/automation/constructTree.sh
@@ -47,7 +47,7 @@ EOF
 }
 
 # Parse options
-while getopts ":ac:ef:hi:rx:" opt; do
+while getopts ":ac:ehi:rx:" opt; do
     case $opt in
         a)
             EXCLUDE_ACCOUNT_DIRECTORIES="true"
@@ -326,7 +326,7 @@ fi
 
 if [[ "${USE_EXISTING_TREE}" == "true" ]]; then
     if [[ -n "${ROOT_DIR}" && -d "${ROOT_DIR}" ]]; then
-        fatal "ROOT_DIR: ${ROOT_DIR} - could not be found for exsting tree"
+        fatal "ROOT_DIR: ${ROOT_DIR} - could not be found for existing tree"
         exit
     fi
     BASE_DIR="${ROOT_DIR}"

--- a/automation/setContext.sh
+++ b/automation/setContext.sh
@@ -262,7 +262,6 @@ function main() {
 
 
   ### Context from automation provider ###
-
   # TODO(rossmurr4y): seperate out azure pipelines
   case "${AUTOMATION_PROVIDER}" in
     jenkins)
@@ -325,6 +324,7 @@ function main() {
       # Job identifier
       AUTOMATION_JOB_IDENTIFIER="${BUILD_NUMBER}"
       ;;
+
     azurepipelines)
       save_context_property GIT_USER "${GIT_USER:-$BUILD_USER}"
       save_context_property GIT_EMAIL "${GIT_EMAIL:-$BUILD_USER_EMAIL}"
@@ -340,7 +340,15 @@ function main() {
 
       save_context_property AUTOMATION_BUILD_SRC_DIR "${WORKSPACE}"
       save_context_property AUTOMATION_BUILD_DEVOPS_DIR "${WORKSPACE}"
-    ;;
+      ;;
+
+    hamletcli)
+        GIT_USER="${GIT_USER:-"$(git config --get user.name)"}"
+        GIT_EMAIL="${GIT_EMAIL:-"$(git config --get user.email)"}"
+
+        save_context_property GIT_USER  "${GIT_USER}"
+        save_context_property GIT_EMAIL "${GIT_EMAIL}"
+        ;;
   esac
 
   # Parse options
@@ -474,18 +482,6 @@ function main() {
       defineRegistryProviderSettings "${REGISTRY_TYPE}" "PRODUCT" "" "${PRODUCT}" "${ENVIRONMENT}" "${ACCOUNT}"
   done
 
-
-  ### Generation framework details ###
-
-  # - git provider
-  defineGitProviderSettings "GENERATION" ""  "${PRODUCT}" "${ENVIRONMENT}" "codeontap"
-
-  # - repos
-  defineRepoSettings "GENERATION" "BIN"      "${PRODUCT}" "${ENVIRONMENT}" "gen3.git"
-  defineRepoSettings "GENERATION" "PATTERNS" "${PRODUCT}" "${ENVIRONMENT}" "gen3-patterns.git"
-  defineRepoSettings "GENERATION" "STARTUP"  "${PRODUCT}" "${ENVIRONMENT}" "gen3-startup.git"
-
-
   ### Application deployment unit details ###
 
   # Determine the deployment unit list and optional corresponding metadata
@@ -511,7 +507,7 @@ function main() {
 
           # Capture any provided git commit
           case ${AUTOMATION_PROVIDER} in
-              jenkins | azurepipelines)
+              jenkins|azurepipelines|hamletcli)
                     [[ -n "${GIT_COMMIT}" ]] && COMMIT_PART="${GIT_COMMIT}"
                     ;;
           esac
@@ -559,7 +555,7 @@ function main() {
 
   # For builds, need to capture any provided git commit even if no deployment units defined at this point
   case ${AUTOMATION_PROVIDER} in
-      jenkins | azurepipelines)
+      jenkins|azurepipelines|hamletcli)
           [[ ( -n "${GIT_COMMIT}" ) && ( -z "${CODE_COMMIT_ARRAY[0]}" ) ]] && CODE_COMMIT_ARRAY[0]="${GIT_COMMIT}"
           ;;
   esac

--- a/execution/setCredentials.sh
+++ b/execution/setCredentials.sh
@@ -16,8 +16,6 @@ if [[ "${ACCOUNT_PROVIDER}" == 'aws' ]]; then
     if [[ -n "${CHECK_AWS_SESSION_TOKEN}" ]]; then export AWS_SESSION_TOKEN="${CHECK_AWS_SESSION_TOKEN}"; fi
 
     # Set the profile for IAM access if AWS credentials not in the environment
-    # We would normally redirect to /dev/null but this triggers an "unknown encoding"
-    # bug in python
     if [[ ((-z "${AWS_ACCESS_KEY_ID}") || (-z "${AWS_SECRET_ACCESS_KEY}")) ]]; then
         if [[ -n "${ACCOUNT}" ]]; then
             aws configure list --profile "${ACCOUNT}" > /dev/null 2>&1


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

Adds support for the hamletcli as an automation provider. This allows for the automation scripts to provide support for using the cli as the script caller

Adds support for running the automation commands locally using the hamletcli provider: 
- Support for using an existing CMDB tree instead of constructing one. The ROOT_DIR must be defined along with the providing USE_EXISTING_TREE to the constructTree.sh script 
- Support for using user defined profiles when the automation scripts require AWS access
- Support for using the users global git config when commit changes to the repo

## Motivation and Context

The motivation behind this change is to to allow the hamlet cli to manage the process of running our automation commands and centralises the dependencies into hamlet maintained components which can run across different providers

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

