### PR TITLE
fix: handle older env vars for docker images

### DIFF
--- a/automation/jenkins/aws/manageImages.sh
+++ b/automation/jenkins/aws/manageImages.sh
@@ -102,6 +102,15 @@ function options() {
     IMAGE_FORMATS="${IMAGE_FORMATS:-${IMAGE_FORMATS_ARRAY[0]}}"
     REGISTRY_SCOPE="${REGISTRY_SCOPE:-${REGISTRY_SCOPE_ARRAY[0]}}"
 
+    # Handle older naming conventions for docker file locations
+    if [[ -n "${DOCKER_CONTEXT_DIR}" ]]; then
+        DOCKER_CONTEXT="${DOCKER_CONTEXT_DIR}"
+    fi
+
+    if [[ -n "${DOCKER_FILE}" ]]; then
+        DOCKERFILE="${DOCKER_FILE#"${DOCKER_CONTEXT_DIR}"}"
+    fi
+
     # Ensure mandatory arguments have been provided
     exit_on_invalid_environment_variables "DEPLOYMENT_UNIT" "CODE_COMMIT" "IMAGE_FORMATS"
 


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

- adds support for older variable names used when providing a docker image to manageImages. 
- adds prefix removal if the path to the dockerfile matches the context. This ensures the dockerfile is relative to the
context

## Motivation and Context

Builds for existing pipelines were failing based on the new format

## How Has This Been Tested?

Tested locally

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

