### PR TITLE
fix: typo in existing tree check

### DIFF
--- a/automation/constructTree.sh
+++ b/automation/constructTree.sh
@@ -94,7 +94,7 @@ USE_EXISTING_TREE="${USE_EXISTING_TREE:-false}"
 # Check for required context
 [[ -z "${ACCOUNT}" ]] && fatal "ACCOUNT not defined" && exit
 
-if [[ "${USE_EXISITNG_TREE}" == "false" ]]; then
+if [[ "${USE_EXISTING_TREE}" == "false" ]]; then
 
     # Save for later steps
     save_context_property PRODUCT_CONFIG_REFERENCE "${PRODUCT_CONFIG_REFERENCE}"


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

Fixes a typo in constructTree which was bypassing cloning

## Motivation and Context

Causing builds to fail 

## How Has This Been Tested?

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

