### PR TITLE
fix: remove stripping from context path for image

### DIFF
--- a/automation/jenkins/aws/manageImages.sh
+++ b/automation/jenkins/aws/manageImages.sh
@@ -108,7 +108,7 @@ function options() {
     fi
 
     if [[ -n "${DOCKER_FILE}" ]]; then
-        DOCKERFILE="${DOCKER_FILE#"${DOCKER_CONTEXT_DIR}"}"
+        DOCKERFILE="${DOCKER_FILE}"
     fi
 
     # Ensure mandatory arguments have been provided


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

Removes a bug where the dockerfile was stripped based on context. Not required and breaks explicit path config

## Motivation and Context

Causing builds to fail

## How Has This Been Tested?

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

