### PR TITLE
fix: use pull for remote image s3 pulls

### DIFF
--- a/automation/jenkins/aws/manageBuildReferences.sh
+++ b/automation/jenkins/aws/manageBuildReferences.sh
@@ -579,7 +579,7 @@ for ((INDEX=0; INDEX<${#DEPLOYMENT_UNIT_ARRAY[@]}; INDEX++)); do
                                 RESULT=$?
                                 ;;
                             lambda|pipeline|scripts|openapi|swagger|spa|contentnode)
-                                ${AUTOMATION_DIR}/manageS3Registry.sh -v \
+                                ${AUTOMATION_DIR}/manageS3Registry.sh -p \
                                     -y "${IMAGE_FORMAT,,}" \
                                     -f "${IMAGE_FORMAT,,}.zip" \
                                     -a "${IMAGE_PROVIDER}" \


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

regression fix for handling image pulls from remote sources when using s3 registries

## Motivation and Context

When trying to pull images from an S3 registry the script was running the verify operation when it should be pulling the image from the remote registry

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

