### PR TITLE
feat: extend logging for invalid image formats

### DIFF
--- a/automation/jenkins/aws/manageBuildReferences.sh
+++ b/automation/jenkins/aws/manageBuildReferences.sh
@@ -497,7 +497,14 @@ for ((INDEX=0; INDEX<${#DEPLOYMENT_UNIT_ARRAY[@]}; INDEX++)); do
             # Most likely it is the first time this unit has been mentioned and no format was
             # included as part of the prepare operation.
             [[ "${IMAGE_FORMATS}" == "?" ]] &&
-                        fatal "Image format(s) not known for \"${CURRENT_DEPLOYMENT_UNIT}\" deployment unit. Provide the format after the code reference separated by \"!\" if unit is being mentioned for the first time." && RESULT=1 && exit
+                {
+                    fatal "Image format(s) not known for \"${CURRENT_DEPLOYMENT_UNIT}\" deployment unit"
+                    fatal "Valid image formats are ${REGISTRY_TYPES_LIST}"
+                    fatal "Automation scripts: Provide the format after the code reference separated by \"!\" if unit is being mentioned for the first time."
+                    fatal "hamlet cli: provide the --image-format option"
+                    RESULT=1
+                    exit
+                }
 
             for IMAGE_FORMAT in "${CODE_IMAGE_FORMATS_ARRAY[@]}"; do
                 IMAGE_PROVIDER_VAR="PRODUCT_${IMAGE_FORMAT^^}_PROVIDER"

--- a/automation/setContext.sh
+++ b/automation/setContext.sh
@@ -157,6 +157,9 @@ function defineGitProviderSettings() {
 }
 
 REGISTRY_TYPES=("dataset" "docker" "lambda" "pipeline" "scripts" "swagger" "openapi" "spa" "contentnode" "rdssnapshot" )
+
+save_context_property "REGISTRY_TYPES_LIST"  "$(listFromArray "REGISTRY_TYPES" ",")"
+
 REGISTRY_PROVIDERS=()
 function defineRegistryProviderSettings() {
     # Define key values about use of a docker provider


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

Adds extra details to the log message when an invalid image format is provided.
Saves the registry types as a list in setContext so they can be used in the message

## Motivation and Context

Make it easier to understand when things go wrong or are missing

## How Has This Been Tested?

Tested locally 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

