### PR TITLE
fix: credentials utility access

### DIFF
--- a/execution/setCredentialsSource.sh
+++ b/execution/setCredentialsSource.sh
@@ -10,6 +10,9 @@ CRED_ACCOUNT="${1^^}"
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 [[ -n "${GENERATION_DEBUG}" ]] && set ${GENERATION_DEBUG}
 
+# Make sure we have utilities available
+. ${GENERATION_BASE_DIR}/execution/utility.sh
+
 # -- AWS - config helper functions
 function set_aws_profile_role_arn {
     local profile_name="${1}"; shift


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

Minor fix to always make sure we have the save_context_property utility available 

## Motivation and Context

In some cases the source configuration wasn't working 

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

