### PR TITLE
fix(docker): ecr repository lookup credentials

### DIFF
--- a/automation/jenkins/aws/manageDocker.sh
+++ b/automation/jenkins/aws/manageDocker.sh
@@ -226,7 +226,7 @@ function createRepository() {
             local registry_region="$(cut -d '.' -f 4 <<< "${registry}")"
             local registry_account="$(cut -d '.' -f 1 <<< "${registry}")"
 
-            if [[ -z "$(aws --profile "${registry_account}" --region ap-southeast-2 ecr describe-repositories --registry-id "${registry_account}" --query "repositories[?repositoryName=='${repository}'].repositoryName" --output text || return $?)" ]]; then
+            if [[ -z "$(aws --region "${registry_region}" ecr describe-repositories --registry-id "${registry_account}" --query "repositories[?repositoryName=='${repository}'].repositoryName" --output text || return $?)" ]]; then
                 # Not there yet so create it
                 aws --region ${registry_region} ecr create-repository --repository-name "${repository}" || return $?
             fi


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

fixes an issue with the credentials used to check of an ecr repositoryexists in the registry

## Motivation and Context

Pull jobs were failing with the wrong credentials

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

