### PR TITLE
fix: resetting of temporary file stack

### DIFF
--- a/automation/constructTree.sh
+++ b/automation/constructTree.sh
@@ -341,10 +341,5 @@ RESULT=$? && [[ ${RESULT} -ne 0 ]] && exit
 # locate the AWS account number to account id mappings
 export GENERATION_DATA_DIR="${BASE_DIR}"
 
-# Check the cmdb doesn't need upgrading
-debug "Checking if cmdb upgrade needed ..."
-upgrade_cmdb "${BASE_DIR}" ||
-    { RESULT=$?; fatal "CMDB upgrade failed."; exit; }
-
 # Remember directories for future steps
 save_gen3_dirs_in_context

--- a/automation/setContext.sh
+++ b/automation/setContext.sh
@@ -156,10 +156,6 @@ function defineGitProviderSettings() {
         "API_DNS" "${DGPD_PROVIDER}" "${DGPD_PROVIDER_TYPE}" "value" "api.${NAME_VALUE}"
 }
 
-REGISTRY_TYPES=("dataset" "docker" "lambda" "pipeline" "scripts" "swagger" "openapi" "spa" "contentnode" "rdssnapshot" )
-
-save_context_property "REGISTRY_TYPES_LIST"  "$(listFromArray "REGISTRY_TYPES" ",")"
-
 REGISTRY_PROVIDERS=()
 function defineRegistryProviderSettings() {
     # Define key values about use of a docker provider
@@ -737,6 +733,9 @@ function main() {
   save_context_property AUTOMATION_JOB_IDENTIFIER
   save_context_property AUTOMATION_RELEASE_IDENTIFIER
   save_context_property AUTOMATION_DEPLOYMENT_IDENTIFIER
+
+  REGISTRY_TYPES=("dataset" "docker" "lambda" "pipeline" "scripts" "swagger" "openapi" "spa" "contentnode" "rdssnapshot" )
+  save_context_property "REGISTRY_TYPES_LIST"  "$(listFromArray "REGISTRY_TYPES" ",")"
 
   # All good
   RESULT=0

--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -561,7 +561,9 @@ function getTempDir() {
     mktemp -d "$(getOSTempRootDir)/${template}"
 }
 
-export tmp_dir_stack=()
+# Initial the temporary directory stack but only if it
+# isn't already in use
+arrayIsEmpty "tmp_dir_stack" && export tmp_dir_stack=()
 
 function pushTempDir() {
   local template="$1"; shift
@@ -903,8 +905,8 @@ function save_context_property() {
   fi
 
   if [[ -z "${file}" ]]; then
-    debug "Saving context property to ${context_temp_file} - AUTOMATION_DATA_DIR not defined"
     file="$( getTempFile "XXXXXX")"
+    debug "Saving context property to ${file} - AUTOMATION_DATA_DIR not defined"
   fi
 
   if [[ -n "${value}" ]]; then


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
Previously each invocation of `utility.sh` would empty the temporary file stack. With the adding of a call to `setCredentials.sh` (which sources `utility.sh`) in `createTemplate.sh` when running a script, the previously established temporary directory was lost resulting in the failure of subsequent template passes.

Along the way, a couple of other things were noted and fixed;
- the cmdb migration process was still being run by `constructTree.sh`
- the saving of registry types was happening BEFORE `AUTOMATION_DATA_DIR` was set, this variable being used by the `save_context_property` function used to save the registry types. As a result, the registry types were being saved to a temporary file which was then not accessible once `AUTOMATION_DATA_DIR` was defined.


## Motivation and Context
Template generation is failing when trying to generate a template for an api gateway which uses a pregeneration script and triggers the bug.

## How Has This Been Tested?
Will be tested on automation server once merged

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

