### PR TITLE
fix: registry type definitions location

### DIFF
--- a/automation/setContext.sh
+++ b/automation/setContext.sh
@@ -472,6 +472,7 @@ function main() {
   defineGitProviderSettings "PRODUCT" "CODE" "${PRODUCT}" "${ENVIRONMENT}" "${PRODUCT_GIT_PROVIDER}"
 
   # - local registry providers
+  REGISTRY_TYPES=("dataset" "docker" "lambda" "pipeline" "scripts" "swagger" "openapi" "spa" "contentnode" "rdssnapshot" )
   for REGISTRY_TYPE in "${REGISTRY_TYPES[@]}"; do
       defineRegistryProviderSettings "${REGISTRY_TYPE}" "PRODUCT" "" "${PRODUCT}" "${ENVIRONMENT}" "${ACCOUNT}"
   done
@@ -733,8 +734,6 @@ function main() {
   save_context_property AUTOMATION_JOB_IDENTIFIER
   save_context_property AUTOMATION_RELEASE_IDENTIFIER
   save_context_property AUTOMATION_DEPLOYMENT_IDENTIFIER
-
-  REGISTRY_TYPES=("dataset" "docker" "lambda" "pipeline" "scripts" "swagger" "openapi" "spa" "contentnode" "rdssnapshot" )
   save_context_property "REGISTRY_TYPES_LIST"  "$(listFromArray "REGISTRY_TYPES" ",")"
 
   # All good


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)


## Description

Move the REGISTRY_TYPES to where they are first used within setContext

## Motivation and Context

REGISTRY_PROVIDERS could not be found and auth wasn't working

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

