### PR TITLE
fix(sentry): specify a sentry url prefix for expo-managed apps

### DIFF
--- a/cli/runExpoAppPublish.sh
+++ b/cli/runExpoAppPublish.sh
@@ -442,11 +442,13 @@ function main() {
     fi
 
 
-  # Defin an archive based on build references to allow for source map replays and troubleshooting
+  # Define an archive based on build references to allow for source map replays and troubleshooting
   EXPO_ARCHIVE_S3_URL="s3://${PUBLIC_BUCKET}/${PUBLIC_PREFIX}/archive/${BUILD_REFERENCE}/"
 
   # Make details available for downstream jobs
-  save_context_property "EXPO_ARCHIVE_S3_URL" "${EXPO_ARCHIVE_S3_URL}"
+  save_context_property "EXPO_ARCHIVE_S3_URL" "${EXPO_ARCHIVE_S3_URL}/bundles"
+  # Set prefix for expo-managed applications
+  save_context_property "EXPO_SENTRY_URL_PREFIX" "~/${PUBLIC_PREFIX}/packages/${EXPO_APP_MAJOR_VERSION}/${OTA_VERSION}/bundles"
   save_context_property "BUILD_REFERENCE" "${BUILD_REFERENCE}"
   save_context_property "DEPLOYMENT_UNIT" "${DEPLOYMENT_UNIT}"
   save_context_property "DEPLOYMENT_GROUP" "${DEPLOYMENT_GROUP}"

--- a/cli/runSentryRelease.sh
+++ b/cli/runSentryRelease.sh
@@ -191,11 +191,11 @@ function main() {
         find "${SOURCE_MAP_PATH}" -type f -name "main.jsbundle*" -exec cp {} "${react_source_maps}" \;
         find "${SOURCE_MAP_PATH}" -type f -name "index.android.bundle*" -exec cp {} "${react_source_maps}" \;
 
-        # enfore the react native requirements around paths and url prefix
+        # enforce the react native requirements around paths and url prefix
         SOURCE_MAP_PATH="${react_source_maps}"
 
         if [[ "${SENTRY_URL_PREFIX}" != "~/" ]]; then
-            warn "Overrding the provided URL prefix ${SENTRY_URL_PREFIX} with ~/ to algin with react native requirements"
+            warn "Overriding the provided URL prefix ${SENTRY_URL_PREFIX} with ~/ to align with react native requirements"
             SENTRY_URL_PREFIX="~/"
         fi
     ;;


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bugfix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
Stores an additional context parameter to pass a sentry prefix URL for expo managed apps.
## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
React-native apps are using standard filenames for source files and corresponding source maps. For expo managed apps the prefix needs to be specified in order to load source maps properly during event processing on Sentry side.
The prefix URL for expo-managed apps matches a prefix for a public OTA URL
## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally.
## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

