### PR TITLE
refactor: remove egrep usage for stack status

### DIFF
--- a/cli/manageStack.sh
+++ b/cli/manageStack.sh
@@ -177,7 +177,7 @@ function wait_for_stack_execution() {
       esac
 
       # Watch for roll backs
-      if echo "${stack_status}" | egrep --quiet "*ROLLBACK_COMPLETE"; then
+      if [[ "${stack_status}" == *ROLLBACK_COMPLETE ]]; then
         echo ""
         warning "Stack ${STACK_NAME} could not complete and a rollback was performed"
         get_stack_status_details "${STACK_NAME}" "${stack_state}" "${client_token}"
@@ -187,7 +187,7 @@ function wait_for_stack_execution() {
       fi
 
       # Watch for failures
-      if echo "${stack_status}" | egrep --quiet "*FAILED"; then
+      if [[ "${stack_status}" == *FAILED ]]; then
         echo ""
         fatal "Stack ${STACK_NAME} failed, fix stack before retrying"
         get_stack_status_details "${STACK_NAME}" "${stack_state}" "${client_token}"
@@ -198,7 +198,7 @@ function wait_for_stack_execution() {
       # Finished if complete
       # If the initial create was not saved for any reason, the stack may have a status of CREATE_COMPLETE
       # even though the current operation is an UPDATE
-      if echo "${stack_status}" | egrep --quiet "^(CREATE|UPDATE)_COMPLETE$"; then
+      if [[ "${stack_status}" =~ ^(CREATE|UPDATE)_COMPLETE$ ]]; then
         echo ""
         info "Stack ${STACK_NAME} completed with status ${stack_status}"
         [[ -n "${change_set_state}" ]] && echo "${change_set_state}" > "${CHANGE}"
@@ -207,7 +207,7 @@ function wait_for_stack_execution() {
       fi
 
       # Abort if not still in progress
-      if ! echo "${stack_status}" | egrep --quiet "*_IN_PROGRESS"; then
+      if [[ ! "${stack_status}" == *_IN_PROGRESS ]]; then
         echo ""
         info "Stack ${STACK_NAME} in an unexpected state with status ${stack_status}"
         get_stack_status_details "${STACK_NAME}" "${stack_state}" "${client_token}"

--- a/cli/manageStack.sh
+++ b/cli/manageStack.sh
@@ -195,9 +195,13 @@ function wait_for_stack_execution() {
         break
       fi
 
-      # Finished if complete
-      # If the initial create was not saved for any reason, the stack may have a status of CREATE_COMPLETE
-      # even though the current operation is an UPDATE
+      if [[ "${stack_status}" == "DELETE_COMPLETE" ]]; then
+        echo ""
+        info "Stack ${STACK_NAME} delete completed with status ${stack_status}"
+        break
+      fi
+
+      # Update State and break if the stack operation was completed
       if [[ "${stack_status}" =~ ^(CREATE|UPDATE)_COMPLETE$ ]]; then
         echo ""
         info "Stack ${STACK_NAME} completed with status ${stack_status}"


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description

removes egrep usage in stack management status checks and use bash based regex instead

## Motivation and Context

When running manageStack on an OSX based machine the following error is logged with the current regex used in status checks `egrep: repetition-operator operand invalid`

OSX appears to use a different grep build than whats in linux so the behaviour is different. 

now that the stackStatus variable is a string its possible to use the standard bash expression matching

## How Has This Been Tested?

Tested locally

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

