### PR TITLE
feat: repository staged changes 

### DIFF
--- a/automation/common.sh
+++ b/automation/common.sh
@@ -13,6 +13,7 @@
 
 # Set hamlet local store
 export HAMLET_HOME_DIR="${HAMLET_HOME_DIR:-"${HOME}/.hamlet"}"
+export COMMIT_CACHE_DIR="${HAMLET_HOME_DIR}/commits"
 
 # -- Repositories --
 

--- a/automation/jenkins/aws/manageRepo.sh
+++ b/automation/jenkins/aws/manageRepo.sh
@@ -277,7 +277,7 @@ function defineGitProviderAttributes() {
 
 function set_context() {
   # Parse options
-  while getopts ":b:cd:e:hil:m:n:pr:s:t:u:v:" opt; do
+  while getopts ":b:cd:e:hil:m:n:pqr:s:t:u:v:" opt; do
       case $opt in
           b) REPO_BRANCH="${OPTARG}" ;;
           c) REPO_OPERATION="${REPO_OPERATION_CLONE}" ;;

--- a/automation/jenkins/aws/saveCMDBRepos.sh
+++ b/automation/jenkins/aws/saveCMDBRepos.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+
+[[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
+trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
+
+. "${AUTOMATION_BASE_DIR}/common.sh"
+
+ACCOUNT_REPOS_DEFAULT="false"
+PRODUCT_REPOS_DEFAULT="false"
+
+function options() {
+
+  # Parse options
+  while getopts ":ahm:pr:t:" option; do
+      case "${option}" in
+          a) ACCOUNT_REPOS="true" ;;
+          h) usage; return 1 ;;
+          m) COMMIT_MESSAGE="${OPTARG}" ;;
+          p) PRODUCT_REPOS="true";;
+          r) REFERENCE="${OPTARG}" ;;
+          t) TAG-"${OPTARG}" ;;
+          \?) fatalOption; return 1 ;;
+      esac
+  done
+
+  ACCOUNT_REPOS="${ACCOUNT_REPOS:-${ACCOUNT_REPOS_DEFAULT}}"
+  PRODUCT_REPOS="${PRODUCT_REPOS:-${PRODUCT_REPOS_DEFAULT}}"
+
+  exit_on_invalid_environment_variables "COMMIT_MESSAGE"
+
+  return 0
+}
+
+function usage() {
+  cat <<EOF
+
+DESCRIPTION:
+  save the current state of cmdbs to their repositories
+
+USAGE:
+  $(basename $0)
+
+PARAMETERS:
+
+  (o) -a                         includes account repositories
+      -h                         shows this text
+  (m) -m  COMMIT_MESSAGE         the commit message to use for the save
+  (o) -p                         includes product repositories
+  (o) -r                         the reference branch to commit changes to
+  (o) -t                         the tag to apply
+
+  (m) mandatory, (o) optional, (d) deprecated
+
+DEFAULTS:
+
+
+NOTES:
+
+
+EOF
+}
+
+function main() {
+
+  options "$@" || return $?
+
+  # save account details
+  if [[ "${ACCOUNT_REPOS}" == "true" ]]; then
+
+    info "Committing changes to account repositories"
+
+    if [[ -n "${ACCOUNT_CONFIG_DIR}" ]]; then
+      save_repo "${ACCOUNT_CONFIG_DIR}" "account config" "${COMMIT_MESSAGE}" "${REFERENCE}" "${TAG}" || return $?
+    else
+      warn "Could not find ACCOUNT_CONFIG_DIR"
+    fi
+
+    if [[ -n "${ACCOUNT_INFRASTRUCTURE_DIR}" ]]; then
+      save_repo "${ACCOUNT_INFRASTRUCTURE_DIR}" "account infrastructure" "${COMMIT_MESSAGE}" "${REFERENCE}" "${TAG}"  || return $?
+    else
+      warn "Could not find ACCOUNT_INFRASTRUCTURE_DIR"
+    fi
+  fi
+
+  # save product details
+  if [[ "${PRODUCT_REPOS}" == "true" ]]; then
+
+    info "Committing changes to product repositories"
+
+    if [[ -n "${PRODUCT_CONFIG_DIR}" ]]; then
+      save_product_config "${COMMIT_MESSAGE}" "${REFERENCE}" "${TAG}" || return $?
+    else
+      warn "Could not find PRODUCT_CONFIG_DIR"
+    fi
+
+    if [[ -n "${PRODUCT_INFRASTRUCTURE_DIR}" ]]; then
+      save_product_infrastructure "${COMMIT_MESSAGE}" "${REFERENCE}" "${TAG}" || return $?
+    else
+       warn "Could not find PRODUCT_INFRASTRUCTURE_DIR"
+    fi
+
+    if [[ -n "${PRODUCT_STATE_DIR}" ]]; then
+      save_product_state "${COMMIT_MESSAGE}" "${REFERENCE}" "${TAG}" || return $?
+    else
+      warn "Could not find PRODUCT_STATE_DIR"
+    fi
+  fi
+
+  RESULT=$?
+  return "${RESULT}"
+}
+
+main "$@"

--- a/execution/common.sh
+++ b/execution/common.sh
@@ -28,6 +28,7 @@ done
 export HAMLET_HOME_DIR="${HAMLET_HOME_DIR:-"${HOME}/.hamlet"}"
 export GENERATION_CACHE_DIR="${HAMLET_HOME_DIR}/cache"
 export PLUGIN_CACHE_DIR="${HAMLET_HOME_DIR}/plugins"
+export COMMIT_CACHE_DIR="${HAMLET_HOME_DIR}/commits"
 
 # Set the log level if not set
 export GENERATION_LOG_LEVEL="${GENERATION_LOG_LEVEL:-${LOG_LEVEL_INFORMATION}}"


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

Adds support for deferring repository save events to a  later date instead of commit at the end of an action. 

- Adds support for staging changes made to a cmdb repository so that they can be saved as a batch
- Adds a check for a git repo and skips repository saving it the provided directory is not a repository
- Adds support for formatting multiple staged commit messages into a single commit message
- Adds a script to save all possible CMDBs as a batch. This will capture all of the changes that have been staged and save them under a standard message header

## Motivation and Context

This allows you to perform a number of changes under a single task such as a full release and then save the changes at the end of the process. This also ensures that deploys and build states don't get out of whack if they are all done in the same pipeline

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

