### PR TITLE
fix: construct dirs and repo saving

### DIFF
--- a/automation/constructTree.sh
+++ b/automation/constructTree.sh
@@ -322,6 +322,10 @@ if [[ "${USE_EXISTING_TREE}" == "false" ]]; then
     #    fi
 
     fi
+
+    # Examine the structure and define key directories
+    findGen3Dirs "${BASE_DIR}"
+    RESULT=$? && [[ ${RESULT} -ne 0 ]] && exit
 fi
 
 if [[ "${USE_EXISTING_TREE}" == "true" ]]; then
@@ -392,12 +396,11 @@ if [[ "${USE_EXISTING_TREE}" == "true" ]]; then
         exit
     fi
     BASE_DIR="${ROOT_DIR}"
+
+    # Examine the structure and define key directories
+    findGen3Dirs "${ROOT_DIR}" "${TENANT}" "${ACCOUNT}" "${PRODUCT}" "${ENVIRONMENT}" "${SEGMENT}"
+    RESULT=$? && [[ ${RESULT} -ne 0 ]] && exit
 fi
-
-# Examine the structure and define key directories
-
-findGen3Dirs "${BASE_DIR}"
-RESULT=$? && [[ ${RESULT} -ne 0 ]] && exit
 
 # A couple of the older upgrades need GENERATION_DATA_DIR set to
 # locate the AWS account number to account id mappings

--- a/automation/jenkins/aws/manageRepo.sh
+++ b/automation/jenkins/aws/manageRepo.sh
@@ -182,7 +182,7 @@ function push() {
         # Commit changes
         debug "Committing to the ${REPO_LOG_NAME} repo..."
 
-        if [[ -n "${formatted_commit_message}" ]]; then
+        if [[ -z "${formatted_commit_message}" ]]; then
 
             # Break the message in name/value pairs
             conventional_commit_base_body="$(format_conventional_commit_body "${REPO_MESSAGE}")"
@@ -200,7 +200,6 @@ function push() {
                 "${conventional_commit_body}" )"
         fi
 
-        echo "${formatted_commit_message}"
         git commit -m "${formatted_commit_message}"
         RESULT=$? && [[ ${RESULT} -ne 0 ]] && fatal "Can't commit to the ${REPO_LOG_NAME} repo" && return 1
 

--- a/automation/jenkins/aws/saveCMDBRepos.sh
+++ b/automation/jenkins/aws/saveCMDBRepos.sh
@@ -65,44 +65,25 @@ function main() {
   options "$@" || return $?
 
   # save account details
-  if [[ "${ACCOUNT_REPOS}" == "true" ]]; then
+  if [[ "${ACCOUNT_REPOS}" == "true" && -n "${ACCOUNT}" ]]; then
 
     info "Committing changes to account repositories"
 
-    if [[ -n "${ACCOUNT_CONFIG_DIR}" ]]; then
-      save_repo "${ACCOUNT_CONFIG_DIR}" "account config" "${COMMIT_MESSAGE}" "${REFERENCE}" "${TAG}" || return $?
-    else
-      warn "Could not find ACCOUNT_CONFIG_DIR"
-    fi
+    save_repo "${ACCOUNT_CONFIG_DIR}" "account config" "${COMMIT_MESSAGE}" "${REFERENCE}" "${TAG}" || return $?
+    save_repo "${ACCOUNT_INFRASTRUCTURE_DIR}" "account infrastructure" "${COMMIT_MESSAGE}" "${REFERENCE}" "${TAG}"  || return $?
 
-    if [[ -n "${ACCOUNT_INFRASTRUCTURE_DIR}" ]]; then
-      save_repo "${ACCOUNT_INFRASTRUCTURE_DIR}" "account infrastructure" "${COMMIT_MESSAGE}" "${REFERENCE}" "${TAG}"  || return $?
-    else
-      warn "Could not find ACCOUNT_INFRASTRUCTURE_DIR"
-    fi
   fi
 
   # save product details
-  if [[ "${PRODUCT_REPOS}" == "true" ]]; then
+  if [[ "${PRODUCT_REPOS}" == "true" && -n "${PRODUCT}" ]]; then
 
     info "Committing changes to product repositories"
 
-    if [[ -n "${PRODUCT_CONFIG_DIR}" ]]; then
-      save_product_config "${COMMIT_MESSAGE}" "${REFERENCE}" "${TAG}" || return $?
-    else
-      warn "Could not find PRODUCT_CONFIG_DIR"
-    fi
-
-    if [[ -n "${PRODUCT_INFRASTRUCTURE_DIR}" ]]; then
-      save_product_infrastructure "${COMMIT_MESSAGE}" "${REFERENCE}" "${TAG}" || return $?
-    else
-       warn "Could not find PRODUCT_INFRASTRUCTURE_DIR"
-    fi
+    save_product_config "${COMMIT_MESSAGE}" "${REFERENCE}" "${TAG}" || return $?
+    save_product_infrastructure "${COMMIT_MESSAGE}" "${REFERENCE}" "${TAG}" || return $?
 
     if [[ -n "${PRODUCT_STATE_DIR}" ]]; then
       save_product_state "${COMMIT_MESSAGE}" "${REFERENCE}" "${TAG}" || return $?
-    else
-      warn "Could not find PRODUCT_STATE_DIR"
     fi
   fi
 


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

- Handles locating the gen3 directories when an existing tree is used by constructTree
- fixes the creation of commit message if one cannot be found
- rely on constructTree to find the directories required for saving all cmdbs
- Include a check for account or product when saving CMDBS

## Motivation and Context

Further testing revealed some issues in the save cmdb process which was caused by some issues in the handling of an existing CMDB for automation jobs

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

