### PR TITLE
fix: errors on saving repo state

### DIFF
--- a/automation/jenkins/aws/manageRepo.sh
+++ b/automation/jenkins/aws/manageRepo.sh
@@ -131,7 +131,7 @@ function push() {
 
         return 0
     else
-        if [[ -f "${commit_stage_file}" ]]; then
+        if [[ -s "${commit_stage_file}" ]]; then
 
             commit_msg_file="$( getTempFile XXXXXXX )"
             staged_commits="$( jq -r --arg dir "${REPO_DIR}" '.dirs[] | select(.dir == $dir) | .message' "${commit_stage_file}")"
@@ -256,8 +256,10 @@ function push() {
     fi
 
     # Removing commits which have been pushed
-    remaining_commits="$(jq --arg dir "${REPO_DIR}" 'del(.dirs[] | select(.dir == $dir))' "${commit_stage_file}")"
-    echo "${remaining_commits}" > "${commit_stage_file}"
+    if [[ -s "${commit_stage_file}" ]]; then
+        remaining_commits="$(jq --arg dir "${REPO_DIR}" 'del(.dirs[] | select(.dir == $dir))' "${commit_stage_file}")"
+        echo "${remaining_commits}" > "${commit_stage_file}"
+    fi
 }
 
 # Define git provider attributes


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

- Adds a check that the commit stage file has content before filtering is applied
- uses content and file instead of just file exists for commit checking

## Motivation and Context

When no staged changes were stored in the commit file an error was being logged by jq 

fixes: https://github.com/hamlet-io/engine/issues/1799

## How Has This Been Tested?

Tested locally 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

