### PR TITLE
fix(ssh): use a file when providing the key

### DIFF
--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -1942,9 +1942,11 @@ function update_ssh_credentials() {
   local name="$1"; shift
   local key_file="$1"; shift
 
+  local ssh_key_file="$( getTempFile ssh_pub_key_XXXXX )"
+
   chmod 400 "${key_file}"
-  crt_content="$(ssh-keygen -y -f "${key_file}")"
-  aws --region "${region}" ec2 import-key-pair --key-name "${name}" --public-key-material "${crt_content}"
+  ssh-keygen -y -f "${key_file}" > "${ssh_key_file}"
+  aws --region "${region}" ec2 import-key-pair --key-name "${name}" --public-key-material "fileb://${ssh_key_file}"
 }
 
 function delete_ssh_credentials() {


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

When providing the ssh-key as a string it needs to be base64 encoded or as a file. Using a file instead to align with what the aws examples have

## Motivation and Context

works on aws cli v1 and v2 and allow for the key to be uplaoded

## How Has This Been Tested?

tested on deployment with issues

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

