### PR TITLE
fix(automation): save cmdb config

### DIFF
--- a/automation/constructTree.sh
+++ b/automation/constructTree.sh
@@ -91,9 +91,6 @@ EXCLUDE_ACCOUNT_DIRECTORIES="${EXCLUDE_ACCOUNT_DIRECTORIES:-false}"
 EXCLUDE_PRODUCT_DIRECTORIES="${EXCLUDE_PRODUCT_DIRECTORIES:-false}"
 USE_EXISTING_TREE="${USE_EXISTING_TREE:-false}"
 
-# Check for required context
-[[ -z "${ACCOUNT}" ]] && fatal "ACCOUNT not defined" && exit
-
 if [[ "${USE_EXISTING_TREE}" == "false" ]]; then
 
     # Save for later steps
@@ -230,6 +227,9 @@ if [[ "${USE_EXISTING_TREE}" == "false" ]]; then
     fi
 
     if [[ !("${EXCLUDE_ACCOUNT_DIRECTORIES}" == "true") ]]; then
+
+        # Check for required context
+        [[ -z "${ACCOUNT}" ]] && fatal "ACCOUNT not defined" && exit
 
         # Multiple accounts in the account config repo
         MULTI_ACCOUNT_REPO=false

--- a/automation/jenkins/aws/saveCMDBRepos.sh
+++ b/automation/jenkins/aws/saveCMDBRepos.sh
@@ -68,8 +68,7 @@ function main() {
   if [[ "${ACCOUNT_REPOS}" == "true" && -n "${ACCOUNT}" ]]; then
 
     info "Committing changes to account repositories"
-
-    save_repo "${ACCOUNT_CONFIG_DIR}" "account config" "${COMMIT_MESSAGE}" "${REFERENCE}" "${TAG}" || return $?
+    save_repo "${ACCOUNT_DIR}" "account config" "${COMMIT_MESSAGE}" "${REFERENCE}" "${TAG}" || return $?
     save_repo "${ACCOUNT_INFRASTRUCTURE_DIR}" "account infrastructure" "${COMMIT_MESSAGE}" "${REFERENCE}" "${TAG}"  || return $?
 
   fi

--- a/automation/setContext.sh
+++ b/automation/setContext.sh
@@ -439,17 +439,19 @@ function main() {
   findAndDefineSetting "ACCOUNT_PROVIDER" "ACCOUNT_PROVIDER" "${ACCOUNT}" "" "value" "aws"
 
   # - access credentials
-  case "${ACCOUNT_PROVIDER}" in
-      aws)
-          AUTOMATION_DIR="${AUTOMATION_PROVIDER_DIR}/${ACCOUNT_PROVIDER}"
-          . ${AUTOMATION_DIR}/setCredentials.sh "${ACCOUNT}"
-          ;;
+  if [[ "${AUTOMATION_CONTEXT_CREDENTIALS:-"true"}" == "true" ]]; then
+    case "${ACCOUNT_PROVIDER}" in
+        aws)
+            AUTOMATION_DIR="${AUTOMATION_PROVIDER_DIR}/${ACCOUNT_PROVIDER}"
+            . ${AUTOMATION_DIR}/setCredentials.sh "${ACCOUNT}"
+            ;;
 
-        azure)
-          AUTOMATION_DIR="${AUTOMATION_PROVIDER_DIR}/aws"
-          . ${AUTOMATION_DIR}/setCredentials.sh "${ACCOUNT}"
-          ;;
-  esac
+            azure)
+            AUTOMATION_DIR="${AUTOMATION_PROVIDER_DIR}/aws"
+            . ${AUTOMATION_DIR}/setCredentials.sh "${ACCOUNT}"
+            ;;
+    esac
+  fi
 
   # - cmdb git provider
   defineGitProviderSettings "ACCOUNT" "" "${ACCOUNT}" "" "github"

--- a/execution/setStackContext.sh
+++ b/execution/setStackContext.sh
@@ -13,18 +13,6 @@
 # Set up the context
 . "${GENERATION_BASE_DIR}/execution/setContext.sh"
 
-case $LEVEL in
-    account|product)
-        [[ ! ("${LEVEL}" =~ ${LOCATION} ) ]] &&
-            fatalLocation "Current directory doesn't match requested level \"${LEVEL}\"."
-        ;;
-    solution|segment|application|multiple)
-        [[ ! ("segment" =~ ${LOCATION} ) ]] &&
-            fatalLocation "Current directory doesn't match requested level \"${LEVEL}\"."
-        ;;
-esac
-
-
 # Determine the details of the template to be created
 PRODUCT_PREFIX="${PRODUCT}"
 LEVEL_PREFIX="${LEVEL}-"


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)


## Description

A collection of fixes and minor improvements around saving cmdb state 
- fixes determining the account using an existing CMDB tree in the automation context 
- Removes location checks in setStackContext as they are no longer required 
- Adds support for disabling Cloud provider credentials setup when its not required for automation 
- Fixes the use of the wrong directory when saving the cmdb state

## Motivation and Context

A number of bugs found when testing the CMDB save state on a test pipeline 

## How Has This Been Tested?

Tested locally 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

