### PR TITLE
fix: remove return from change set creation

### DIFF
--- a/cli/manageStack.sh
+++ b/cli/manageStack.sh
@@ -284,7 +284,9 @@ function process_stack() {
       fi
 
       PRIMARY_CHANGE_SET="$(fileBase "${TEMPLATE}")-${change_set_id}"
-      submit_change_set "${REGION}" "${PRIMARY_CHANGE_SET}" "${STACK_NAME}" "${STACK_OPERATION}" "${stripped_primary_template_file}" || return $?
+
+      # This will return a non zero exit code if there is no change to the change set - so we want to ignore the exit status here
+      submit_change_set "${REGION}" "${PRIMARY_CHANGE_SET}" "${STACK_NAME}" "${STACK_OPERATION}" "${stripped_primary_template_file}"
 
       change_set_state="$(aws --region "${REGION}" cloudformation describe-change-set \
             --stack-name "${STACK_NAME}" --change-set-name "${PRIMARY_CHANGE_SET}" || return $?)"


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

Ignore the exit status when submitting a change set

## Motivation and Context

Was causing no op deployments to fail the overall run-deployment 

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

