### PR TITLE
fix: automation executor updates

### DIFF
--- a/execution/common.sh
+++ b/execution/common.sh
@@ -58,7 +58,11 @@ function getTempRootDir() {
 }
 
 # Check the root of the context tree can be located
-export GENERATION_DATA_DIR=$(findGen3RootDir "${ROOT_DIR:-$(pwd)}")
+if [[ -n "${ROOT_DIR}" ]]; then
+  export GENERATION_DATA_DIR="${ROOT_DIR}"
+else
+  export GENERATION_DATA_DIR="$(findGen3RootDir "$(pwd)")"
+fi
 debug "GENERATION_DATA_DIR=${GENERATION_DATA_DIR}"
 
 # Cache for assembled components

--- a/execution/setCredentialsSource.sh
+++ b/execution/setCredentialsSource.sh
@@ -282,7 +282,7 @@ case "${ACCOUNT_PROVIDER}" in
                     fatal "  - Hamlet Account Id: ${CRED_ACCOUNT}"
                     fatal "  - AWS Account Id: ${local_aws_account_id}"
                     fatal "  - HAMLET_AWS_AUTH_SOURCE: ${local_aws_auth_source}"
-                    fatal "  - HAMLET_AWS_AUTH_ROLE: ${local_aws_aith_role}"
+                    fatal "  - HAMLET_AWS_AUTH_ROLE: ${local_aws_auth_role}"
                     fatal "Check your aws credentials configuration and try again"
                     fatal "Make sure to set HAMLET_AWS_AUTH_ROLE if you need to switch role to access the account"
                     exit 128


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

- Fixes a variable name in the fatal messages that was hiding the role that was attempted
- Skips searching for the root dir if it has already been defined

## Motivation and Context

- Variable name makes it easier to follow what went wrong when running a command 
- Skipping the root dir search means that we don't need to create the root.json file if it has already been set

## How Has This Been Tested?

Tested locally 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

