### PR TITLE
fix: env credential switching

### DIFF
--- a/execution/setCredentialsSource.sh
+++ b/execution/setCredentialsSource.sh
@@ -98,11 +98,14 @@ case "${ACCOUNT_PROVIDER}" in
 
                 hamlet_aws_profile="source:env"
 
-                aws configure set "profile.${hamlet_aws_profile}.aws_access_key_id" "${AWS_ACCESS_KEY_ID}"
-                aws configure set "profile.${hamlet_aws_profile}.aws_secret_access_key" "${AWS_SECRET_ACCESS_KEY}"
+                if [[ -n "${AWS_ACCESS_KEY_ID}" && -n "${AWS_SECRET_ACCESS_KEY}" ]]; then
 
-                if [[ -n "${AWS_SESSION_TOKEN}" ]]; then
-                    aws configure set "profile.${hamlet_aws_profile}.aws_session_token" "${AWS_SESSION_TOKEN}"
+                    aws configure set "profile.${hamlet_aws_profile}.aws_access_key_id" "${AWS_ACCESS_KEY_ID}"
+                    aws configure set "profile.${hamlet_aws_profile}.aws_secret_access_key" "${AWS_SECRET_ACCESS_KEY}"
+
+                    if [[ -n "${AWS_SESSION_TOKEN}" ]]; then
+                        aws configure set "profile.${hamlet_aws_profile}.aws_session_token" "${AWS_SESSION_TOKEN}"
+                    fi
                 fi
 
                 set_aws_mfa_token_serial "${hamlet_aws_profile}" "${local_aws_auth_mfa_serial}"


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

Only update the credentials profile for environment credentials when the source variables have content

## Motivation and Context

When setCredentials was called during a task where it needed to switch accounts the env credentials were being wiped as we clear the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables in order to use profiles

## How Has This Been Tested?

Tested locally 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

