### PR TITLE
refactor: remove dos2unix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: add build details
         run: |
-          pip install hamlet-cli
+          pip install hamlet
           hamlet engine add-engine-source-build
 
       - name: docker meta details

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ See https://docs.hamlet.io for more info on Hamlet Deploy
 
 ## Installation
 
-The bash executor is included as part of the official [hamlet base engine](https://github.com/hamlet-io/hamlet-engine-base/) so it will be included as part of your hamlet installation if you are using the [hamlet cli](https://pypi.org/project/hamlet-cli/)
+See the [hamlet install guide](https://docs.hamlet.io/docs/getting-started/install) for details on how to install hamlet
 
 ### Alternative Method
 

--- a/cli/manageCrypto.sh
+++ b/cli/manageCrypto.sh
@@ -323,10 +323,10 @@ function main() {
     # base64 decode if necessary
     if [[ (-n "${CRYPTO_DECODE}") ]]; then
         # Sanity check on input
-        dos2unix < "${ciphertext_src}" | grep -q "${BASE64_REGEX}"
+        grep -q "${BASE64_REGEX}" "${ciphertext_src}"
         RESULT=$?
         if [[ "${RESULT}" -eq 0 ]]; then
-            dos2unix < "${ciphertext_src}" | base64 -d  > "${ciphertext_bin}"
+            base64 -d "${ciphertext_src}" > "${ciphertext_bin}"
         else
             fatal "Input doesn't appear to be base64 encoded"
             return 255
@@ -377,7 +377,7 @@ function main() {
 
         # Decode if required
         if [[ "${CRYPTO_VISIBLE}" == "true" ]]; then
-            CRYPTO_TEXT=$(dos2unix <<< "${CRYPTO_TEXT}" | base64 -d)
+            CRYPTO_TEXT=$(base64 -d <<< "${CRYPTO_TEXT}" |
         fi
 
         # Update if required

--- a/cli/manageCrypto.sh
+++ b/cli/manageCrypto.sh
@@ -377,7 +377,7 @@ function main() {
 
         # Decode if required
         if [[ "${CRYPTO_VISIBLE}" == "true" ]]; then
-            CRYPTO_TEXT=$(base64 -d <<< "${CRYPTO_TEXT}" |
+            CRYPTO_TEXT="$(base64 -d <<< "${CRYPTO_TEXT}" )"
         fi
 
         # Update if required

--- a/execution/manageJSON.sh
+++ b/execution/manageJSON.sh
@@ -96,5 +96,3 @@ else
     runJQ ${JSON_FORMAT} -s "${JSON_FILTER}" "${JSON_ARRAY[@]}" > ${JSON_OUTPUT}
 fi
 RESULT=$?
-[[ "${RESULT}" -eq 0 ]] && dos2unix "${JSON_OUTPUT}" 2> /dev/null
-#


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description

- Removes dos2unix from hamlet commands and instead relies on external management of file endings
- Updates readme to use the docs install guide 
- Fixes references to hamlet python package in cli

## Motivation and Context

The dos2unix package is not installed in a lot of machines and adds an additional requirement to setting up hamlet. Its use has been limited and tools like git manage line endings anyway. Removing this from hamlet itself reduces the complexity in setting up hamlet

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

