### PR TITLE
fix: revert deployment mode change

### DIFF
--- a/cli/manageDeployment.sh
+++ b/cli/manageDeployment.sh
@@ -245,9 +245,9 @@ function process_deployment() {
         # Execute the deployment to the resource group
         info "${DRYRUN}Starting deployment of ${DEPLOYMENT_NAME} to the Resource Group ${RESOURCE_GROUP}."
         if [ -z ${DRYRUN} ]; then
-          az deployment group create ${group_deployment_args[@]/#/--} --mode Complete --no-wait > /dev/null || return $?
+          az deployment group create ${group_deployment_args[@]/#/--} --mode Incremental --no-wait > /dev/null || return $?
         else
-          az deployment group what-if ${group_deployment_args[@]/#/--} --mode Complete --no-pretty-print > ${potential_change_file} || return $?
+          az deployment group what-if ${group_deployment_args[@]/#/--} --mode Incremental --no-pretty-print > ${potential_change_file} || return $?
         fi
 
       elif [[ "${DEPLOYMENT_SCOPE}" == "subscription" ]]; then


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

Reverts the move to the complete mode for ARM templates. 

## Motivation and Context

This worked in most cases but when a deployed resource creates its own resources as part of the same group the complete mode attempts to clean these resources up. This means that the internal resources by Azure fall over as they no longer have the resources they expected

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

