### PR TITLE
fix(expo): fix sheild args for badge

### DIFF
--- a/cli/runExpoAppPublish.sh
+++ b/cli/runExpoAppPublish.sh
@@ -642,7 +642,7 @@ function main() {
                     which badge || (fatal "badge not installed - run gem install badge to install"; return 128)
 
                     BADGE_CONTENT="${ENVIRONMENT_BADGE_CONTENT:-${ENVIRONMENT}}"
-                    badge_args=("${BADGE_CONTENT}-blue" "--shield_scale" "0.50" "--no_badge" "--shield_gravity" "South" "--shield_parameters" "style=flat")
+                    badge_args=("--shield" "${BADGE_CONTENT}-blue" "--shield_scale" "0.50" "--no_badge" "--shield_gravity" "South" "--shield_parameters" "style=flat")
 
                     # iOS is the default pattern to match
                     badge "${badge_args[@]}" --shield_geometry "+0+5%"


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

- Fixes the arguments passed to badge when adding an environment badge

## Motivation and Context

When configured the badge wasn't been added to the app icons

## How Has This Been Tested?

Tested locally and on active agent 

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

