### PR TITLE
fix: handle failed stack deletes

### DIFF
--- a/cli/manageStack.sh
+++ b/cli/manageStack.sh
@@ -244,7 +244,7 @@ function process_stack() {
           --client-request-token "${DELETE_CLIENT_TOKEN}" 2>/dev/null
 
       # For delete, we don't check result as stack may not exist
-      wait_for_stack_execution "${DELETE_CLIENT_TOKEN}" "${STACK_OPERATION}"
+      wait_for_stack_execution "${DELETE_CLIENT_TOKEN}" "${STACK_OPERATION}" || return $?
       ;;
 
     update|create)
@@ -384,7 +384,7 @@ function process_stack() {
   esac
 
   # Clean up the stack if required
-  if [[ "${STACK_OPERATION}" == "delete" && "${exit_stats}" -eq 0 ]]; then
+  if [[ "${STACK_OPERATION}" == "delete" ]]; then
     for i in ${PSEUDO_STACK_WILDCARD}; do
       rm "${i}"
     done


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)


## Description

- Adds a return on stack execution for delete actions

## Motivation and Context

When a stack deletion failed the stack output files were being removed. They should be kept to ensure that the deployment is treated as still around 

## How Has This Been Tested?

Tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

