### PR TITLE
fix: macOS differences for commands

### DIFF
--- a/automation/jenkins/aws/manageRepo.sh
+++ b/automation/jenkins/aws/manageRepo.sh
@@ -139,7 +139,7 @@ function push() {
     if [[ "${DEFER_REPO_PUSH,,}" == "true" ]]; then
         info "Deferred push saving details for the next requested push"
 
-        commit_time="$( date --iso-8601=seconds )"
+        commit_time="$( date -u +"%Y-%m-%dT%H:%M:%SZ" )"
         echo "${commit_details}" | jq --arg dir "${REPO_DIR}" --arg commit_time "${commit_time}" --arg msg "${REPO_MESSAGE}" '.dirs += [{"dir": $dir, "commit_time": $commit_time, "message": $msg }]' > "${commit_stage_file}"
 
         return 0

--- a/automation/setContext.sh
+++ b/automation/setContext.sh
@@ -558,22 +558,24 @@ function main() {
   esac
 
   # Regenerate the deployment unit list in case the first code commit/tag or format was overriden
-  UPDATED_UNITS_ARRAY=()
-  for INDEX in $( seq 0 $((${#DEPLOYMENT_UNIT_ARRAY[@]}-1)) ); do
-      UPDATED_UNIT=("${DEPLOYMENT_UNIT_ARRAY[$INDEX]}")
-      if [[ "${CODE_TAG_ARRAY[$INDEX]}" != "?" ]]; then
-          UPDATED_UNIT+=("${CODE_TAG_ARRAY[$INDEX]}")
-      else
-          if [[ "${CODE_COMMIT_ARRAY[$INDEX]}" != "?" ]]; then
-              UPDATED_UNIT+=("${CODE_COMMIT_ARRAY[$INDEX]}")
-          fi
-      fi
-      if [[ "${IMAGE_FORMATS_ARRAY[$INDEX]}" != "?" ]]; then
-          UPDATED_UNIT+=("${IMAGE_FORMATS_ARRAY[$INDEX]}")
-      fi
-      UPDATED_UNITS_ARRAY+=("$(listFromArray "UPDATED_UNIT" "${BUILD_REFERENCE_PART_SEPARATORS}")")
-  done
-  UPDATED_UNITS=$(listFromArray "UPDATED_UNITS_ARRAY" "${DEPLOYMENT_UNIT_SEPARATORS}")
+  if [[ -n "${DEPLOYMENT_UNIT_ARRAY}" ]]; then
+    UPDATED_UNITS_ARRAY=()
+    for INDEX in $( seq 0 $((${#DEPLOYMENT_UNIT_ARRAY[@]}-1)) ); do
+        UPDATED_UNIT=("${DEPLOYMENT_UNIT_ARRAY[$INDEX]}")
+        if [[ "${CODE_TAG_ARRAY[$INDEX]}" != "?" ]]; then
+            UPDATED_UNIT+=("${CODE_TAG_ARRAY[$INDEX]}")
+        else
+            if [[ "${CODE_COMMIT_ARRAY[$INDEX]}" != "?" ]]; then
+                UPDATED_UNIT+=("${CODE_COMMIT_ARRAY[$INDEX]}")
+            fi
+        fi
+        if [[ "${IMAGE_FORMATS_ARRAY[$INDEX]}" != "?" ]]; then
+            UPDATED_UNIT+=("${IMAGE_FORMATS_ARRAY[$INDEX]}")
+        fi
+        UPDATED_UNITS_ARRAY+=("$(listFromArray "UPDATED_UNIT" "${BUILD_REFERENCE_PART_SEPARATORS}")")
+    done
+    UPDATED_UNITS=$(listFromArray "UPDATED_UNITS_ARRAY" "${DEPLOYMENT_UNIT_SEPARATORS}")
+  fi
 
   # Save for subsequent processing
   save_context_property DEPLOYMENT_UNIT_LIST "${DEPLOYMENT_UNIT_ARRAY[*]}"

--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -760,7 +760,7 @@ function process_template() {
   [[ ! -d ${cf_dir} ]] && mkdir -p ${cf_dir}
 
   # Create a random string to use as the run identifier
-  run_id="$(dd bs=128 count=1 if=/dev/urandom status=none | base64 | env LC_CTYPE=C tr -dc 'a-z0-9' | fold -w 10 | head -n 1)"
+  run_id="$( echo "${RANDOM}" | sha1sum | fold -w 10 | head -n 1 )"
 
   # Directory for temporary files
   pushTempDir "create_template_XXXXXX"


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description

- replaces dd with the bash RANDOM variable as dd behaves differently across operating systems and RANDOM is based on bash
- skips array lookups if the array is empty for deployment units
- uses the full definition of the iso8601 date format as osx date doesn't have the shorthand option

## Motivation and Context

When running hamlet on macOS/OSX some of the commands different results or expect different arguments. This can lead to random error messages which usually are ignored by hamlet but can be confusing to people looking at the command output

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

