### PR TITLE
feat: log group retention control

### DIFF
--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -1134,6 +1134,14 @@ function create_cloudwatch_event () {
   return ${return_status}
 }
 
+function set_cloudwatch_log_group_retention () {
+  local region="$1"; shift
+  local logGroupName="$1"; shift
+  local retentionInDays="$1"; shift
+
+  aws --region "${region}" logs put-retention-policy --log-group-name "${logGroupName}" --retention-in-days "${retentionInDays}"
+}
+
 # -- CloudFormation --
 function get_cloudformation_stack_output() {
   local region="$1"; shift


### PR DESCRIPTION
## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
Add function to set the retention for a log group.

## Motivation and Context
For log groups created by AWS, it is still desirable to be able to set the retention desired, as the default is for log groups to never expire.

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

