### PR TITLE
fix(cloudwatch): check for log group before retention update

### DIFF
--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -1139,7 +1139,12 @@ function set_cloudwatch_log_group_retention () {
   local logGroupName="$1"; shift
   local retentionInDays="$1"; shift
 
-  aws --region "${region}" logs put-retention-policy --log-group-name "${logGroupName}" --retention-in-days "${retentionInDays}"
+  info "Setting retention period ${retentionInDays} on ${logGroupName}"
+  if [[ -n "$(aws --region "${region}" logs describe-log-groups --output text --query "logGroups[?logGroupName == '${logGroupName}'].logGroupName" || return $?)"  ]]; then
+    aws --region "${region}" logs put-retention-policy --log-group-name "${logGroupName}" --retention-in-days "${retentionInDays}"
+  else
+    info "log group ${logGroupName} not found - will try on next update"
+  fi
 }
 
 # -- CloudFormation --


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Adds a check for the log group before setting retention period

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
If the log group is not found the script will continue to allow for groups which are created on the first log event

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

