### PR TITLE
feat(lambda): add support for lambda jar registry

### DIFF
--- a/automation/jenkins/aws/buildSetup.sh
+++ b/automation/jenkins/aws/buildSetup.sh
@@ -122,6 +122,14 @@ for IMAGE_FORMAT in "${IMAGE_FORMATS_ARRAY[@]}"; do
             [[ "${RESULT}" -eq 0 ]] && PRESENT=1
             ;;
 
+        lambda_jar)
+            ${AUTOMATION_DIR}/manageS3Registry.sh -v \
+                -u "${DEPLOYMENT_UNIT}" -g "${CODE_COMMIT}" -c "${REGISTRY_SCOPE}" \
+                -y "${IMAGE_FORMAT,,}" -f "${IMAGE_FORMAT,,}.jar"
+            RESULT=$?
+            [[ "${RESULT}" -eq 0 ]] && PRESENT=1
+            ;;
+
         *)
             fatal "Unsupported image format \"${IMAGE_FORMAT}\""
             ;;

--- a/automation/jenkins/aws/manageBuildReferences.sh
+++ b/automation/jenkins/aws/manageBuildReferences.sh
@@ -373,6 +373,19 @@ for ((INDEX=0; INDEX<${#DEPLOYMENT_UNIT_ARRAY[@]}; INDEX++)); do
                             RESULT=$?
                             [[ "${RESULT}" -ne 0 ]] && RESULT=1 && exit
                             ;;
+
+                        lambda_jar)
+                            ${AUTOMATION_DIR}/manageS3Registry.sh -k \
+                                -a "${IMAGE_PROVIDER}" \
+                                -u "${REGISTRY_DEPLOYMENT_UNIT}" \
+                                -y "${IMAGE_FORMAT_LOWER}" \
+                                -f "${IMAGE_FORMAT_LOWER}.jar" \
+                                -g "${CODE_COMMIT}" \
+                                -r "${ACCEPTANCE_TAG}" \
+                                -c "${REGISTRY_SCOPE}"
+                            RESULT=$?
+                            [[ "${RESULT}" -ne 0 ]] && RESULT=1 && exit
+                            ;;
                         *)
                             fatal "Unknown image format \"${IMAGE_FORMAT}\"" && RESULT=1 && exit
                             ;;
@@ -546,6 +559,17 @@ for ((INDEX=0; INDEX<${#DEPLOYMENT_UNIT_ARRAY[@]}; INDEX++)); do
                             -c "${REGISTRY_SCOPE}"
                         RESULT=$?
                         ;;
+
+                    lambda_jar)
+                        ${AUTOMATION_DIR}/manageS3Registry.sh -v \
+                            -y "${IMAGE_FORMAT,,}" \
+                            -f "${IMAGE_FORMAT,,}.jar" \
+                            -a "${IMAGE_PROVIDER}" \
+                            -u "${REGISTRY_DEPLOYMENT_UNIT}" \
+                            -g "${CODE_COMMIT}" \
+                            -c "${REGISTRY_SCOPE}"
+                        RESULT=$?
+                        ;;
                     *)
                         fatal "Unknown image format \"${IMAGE_FORMAT}\"" && RESULT=1 && exit
                         ;;
@@ -589,6 +613,18 @@ for ((INDEX=0; INDEX<${#DEPLOYMENT_UNIT_ARRAY[@]}; INDEX++)); do
                                 ${AUTOMATION_DIR}/manageS3Registry.sh -p \
                                     -y "${IMAGE_FORMAT,,}" \
                                     -f "${IMAGE_FORMAT,,}.zip" \
+                                    -a "${IMAGE_PROVIDER}" \
+                                    -u "${REGISTRY_DEPLOYMENT_UNIT}" \
+                                    -g "${CODE_COMMIT}" \
+                                    -r "${VERIFICATION_TAG}" \
+                                    -z "${FROM_IMAGE_PROVIDER}" \
+                                    -c "${REGISTRY_SCOPE}"
+                                RESULT=$?
+                                ;;
+                            lambda_jar)
+                                ${AUTOMATION_DIR}/manageS3Registry.sh -p \
+                                    -y "${IMAGE_FORMAT,,}" \
+                                    -f "${IMAGE_FORMAT,,}.jar" \
                                     -a "${IMAGE_PROVIDER}" \
                                     -u "${REGISTRY_DEPLOYMENT_UNIT}" \
                                     -g "${CODE_COMMIT}" \

--- a/automation/setContext.sh
+++ b/automation/setContext.sh
@@ -474,7 +474,7 @@ function main() {
   defineGitProviderSettings "PRODUCT" "CODE" "${PRODUCT}" "${ENVIRONMENT}" "${PRODUCT_GIT_PROVIDER}"
 
   # - local registry providers
-  REGISTRY_TYPES=("dataset" "docker" "lambda" "pipeline" "scripts" "swagger" "openapi" "spa" "contentnode" "rdssnapshot" )
+  REGISTRY_TYPES=("dataset" "docker" "lambda" "lambda_jar" "pipeline" "scripts" "swagger" "openapi" "spa" "contentnode" "rdssnapshot" )
   for REGISTRY_TYPE in "${REGISTRY_TYPES[@]}"; do
       defineRegistryProviderSettings "${REGISTRY_TYPE}" "PRODUCT" "" "${PRODUCT}" "${ENVIRONMENT}" "${ACCOUNT}"
   done


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for providing JAR files as images for lambda functions

This adds a new build format lambda_jar which can be specified when uploading an image. The lambda function in the component will prefer the presence of the lambda jar over standard lambda zip functions

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Allows for support of java based lambda functions in their native package format

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
tested locally using hamlet cli 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

