### PR TITLE
fix: sleep command formatting for compatability

### DIFF
--- a/cli/snapshotRDSDatabase.sh
+++ b/cli/snapshotRDSDatabase.sh
@@ -139,7 +139,7 @@ if [[ ("${RETAIN}" != "") || ("${AGE}" != "") ]]; then
 fi
 
 if [[ "${WAIT}" == "true" ]]; then
-    sleep 5s
+    sleep 5
     while [ "${exit_status}" != "0" ]; do
         SNAPSHOT_STATE="$(aws --region "${REGION}" rds describe-db-snapshots --db-snapshot-identifier "${DB_SNAPSHOT_IDENTIFIER}" --query 'DBSnapshots[0].Status' || return $? )"
         SNAPSHOT_PROGRESS="$(aws --region "${REGION}" rds describe-db-snapshots --db-snapshot-identifier "${DB_SNAPSHOT_IDENTIFIER}" --query 'DBSnapshots[0].PercentProgress' || return $? )"

--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -2169,7 +2169,7 @@ function create_snapshot() {
       return 0
     fi
 
-    sleep 5s
+    sleep 5
     while [ "${exit_status}" != "0" ]
     do
         SNAPSHOT_STATE="$(aws --region "${region}" rds describe-db-cluster-snapshots --db-cluster-snapshot-identifier "${db_snapshot_identifier}" --query 'DBClusterSnapshots[0].Status' || return $? )"
@@ -2193,7 +2193,7 @@ function create_snapshot() {
       return 0
     fi
 
-    sleep 5s
+    sleep 5
     while [ "${exit_status}" != "0" ]
     do
         SNAPSHOT_STATE="$(aws --region "${region}" rds describe-db-snapshots --db-snapshot-identifier "${db_snapshot_identifier}" --query 'DBSnapshots[0].Status' || return $? )"


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Removes the time type from the sleep command

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The sleep command in MacOS only supports providing a number and not the time type to sleep in ( i.e. it only supports seconds ) 
This also aligns the way we use sleep across the bash scripts

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

