### PR TITLE
refactor: use weird seperate for user provided parameters

### DIFF
--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -123,7 +123,7 @@ function options() {
   fi
   FLOWS="$(listFromArray "FLOWS_ARRAY" ",")"
 
-  ENTRANCE_PARAMETERS="$(listFromArray "ENTRANCE_PARAMETERS_ARRAY" ",")"
+  ENTRANCE_PARAMETERS="$(listFromArray "ENTRANCE_PARAMETERS_ARRAY" "||")"
 
   # Ensure other mandatory arguments have been provided
   if [[ (-z "${REQUEST_REFERENCE}") || (-z "${CONFIGURATION_REFERENCE}") ]]; then
@@ -438,7 +438,7 @@ function process_template_pass() {
   args+=("-r" "accountRegion=${account_region}")
 
   # Entrance parameters
-  arrayFromList entranceParametersArray "${entrance_parameters}" ","
+  arrayFromList entranceParametersArray "${entrance_parameters}" "||"
   for entranceParameter in "${entranceParametersArray[@]}"; do
     args+=("-r" "${entranceParameter}")
   done


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
<!--- Describe your changes in detail -->
- change from using , to || to support providing JSON values via entrance parameters

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The current comma separation for entrance parameters within the createTemplate script means that providing a JSON object as an entrance parameter causes createTemplate to split the JSON value which is then not processed by freemarker. Using a sperator like || means that it is unlikely to interfere with user provided inputs

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

