### PR TITLE
fix: macos run_id and expo ouputs

### DIFF
--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -763,8 +763,8 @@ function process_template() {
   # Ensure the aws tree for the templates exists
   [[ ! -d ${cf_dir} ]] && mkdir -p ${cf_dir}
 
-  # Create a random string to use as the run identifier
-  run_id="$( echo "${RANDOM}" | sha1sum | fold -w 10 | head -n 1 )"
+  # Create a random id to use as the run identifier
+  run_id="$(( ${RANDOM} ** 3 ))" && run_id="${run_id:0:10}"
 
   # Directory for temporary files
   pushTempDir "create_template_XXXXXX"

--- a/cli/runExpoAppPublish.sh
+++ b/cli/runExpoAppPublish.sh
@@ -208,6 +208,7 @@ where
 (o) -l BUILD_LOGS                   show the build logs for binary builds
 (o) -e ENVIRONMENT_BADGE            add a badge to the app icons with the environment
 (o) -d ENVIRONMENT_BADGE_CONTENT    override the environment content with your own
+(o) -o OUTPUT_DIR                   The output directory for binaries
 
 (m) mandatory, (o) optional, (d) deprecated
 
@@ -241,7 +242,7 @@ EOF
 function options() {
 
     # Parse options
-    while getopts ":b:d:efg:hk:lmn:sq:t:u:v:" opt; do
+    while getopts ":b:d:efg:hk:lmn:o:sq:t:u:v:" opt; do
         case $opt in
             b)
                 BINARY_BUILD_PROCESS="${OPTARG}"
@@ -272,6 +273,9 @@ function options() {
                 ;;
             n)
                 NODE_PACKAGE_MANAGER="${OPTARG}"
+                ;;
+            o)
+                OUTPUT_DIR="${OPTARG}"
                 ;;
             u)
                 DEPLOYMENT_UNIT="${OPTARG}"
@@ -353,7 +357,7 @@ function main() {
   fi
 
   # Make sure we are in the build source directory
-  BINARY_PATH="${WORKSPACE_DIR}/binary"
+  BINARY_PATH="${OUTPUT_DIR:-${WORKSPACE_DIR}}/binary"
   SRC_PATH="${WORKSPACE_DIR}/src"
   OPS_PATH="${WORKSPACE_DIR}/ops"
   REPORTS_PATH="${WORKSPACE_DIR}/reports"


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
<!--- Describe your changes in detail -->
A couple of fixes around macOS based work

- Change the run_id generation to bash native commands completely
- Add an output dir to expo builds to retrieve binary files when they are created

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Allow for using the hamlet cli to create expo builds and remove errors when generating run_id on osx ( sha1sum isn't available and is instead shasum, we don't need to to be that random anyway so we can just generate a number ) 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

