### PR TITLE
fix(setContext) : AUTOMATION_BUILD_DIR

### DIFF
--- a/automation/setContext.sh
+++ b/automation/setContext.sh
@@ -292,7 +292,7 @@ function main() {
 
       # Build directory
       AUTOMATION_BUILD_DIR="${AUTOMATION_DATA_DIR}"
-      [[ -d build ]] && AUTOMATION_BUILD_DIR="${AUTOMATION_BUILD_DIR}/build"
+      [[ -d "${AUTOMATION_BUILD_DIR}/build" ]] && AUTOMATION_BUILD_DIR="${AUTOMATION_BUILD_DIR}/build"
       if [[ -n "${BUILD_PATH}" ]]; then
         [[ -d "${AUTOMATION_BUILD_DIR}/${BUILD_PATH}" ]] &&
           AUTOMATION_BUILD_DIR="${AUTOMATION_BUILD_DIR}/${BUILD_PATH}" ||


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
Ensure that the checking for a top level `build` directory doesn't depend on the working directory.

## Motivation and Context
If the `dir()` step is being used, it may be convenient to not have to be in the top level workspace directory when calling `setContext.sh`.

## How Has This Been Tested?
Tricky to test - once merged I'll temporarily use the unicycle release in a customer site to confirm nothing breaks.

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

