### PR TITLE
feat: add support for providing the district cli option to templates

### DIFF
--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -427,6 +427,7 @@ function process_template_pass() {
   args+=("-r" "runId=${run_id}")
 
   # Starting layers
+  args+=("-r" "district=${DISTRICT}")
   args+=("-r" "tenant=${TENANT}")
   args+=("-r" "account=${ACCOUNT}")
   args+=("-r" "region=${region}")

--- a/execution/setContext.sh
+++ b/execution/setContext.sh
@@ -101,6 +101,22 @@ if [[ (-f "root.json") || ((-d config) && (-d infrastructure)) ]]; then
     export LOCATION="${LOCATION:-root}"
 fi
 
+# The district determines the layers that are used within the deployment
+# The current user location is a good way to determine the district overall
+if [[ -z "${DISTRICT}" ]]; then
+    case "${LOCATION}" in
+        "account")
+            export DISTRICT="account"
+            ;;
+        "environment")
+            export DISTRCIT="environment"
+            ;;
+        default)
+            export DISTRICT="segment"
+            ;;
+    esac
+fi
+
 cd "${GENERATION_DATA_DIR}"
 [[ -z "${ACCOUNT}" ]] && export ACCOUNT="$(fileName "${GENERATION_DATA_DIR}")"
 


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds the ability to define the district used to assemble layers

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Template generation failing for account level deployment units as the account location doesn't have the layers required to compile a segment district 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

