### PR TITLE
refactor: scope settings search and remove legacy

### DIFF
--- a/automation/constructTree.sh
+++ b/automation/constructTree.sh
@@ -306,21 +306,6 @@ if [[ "${USE_EXISTING_TREE}" == "false" ]]; then
             mkdir -p $(filePath "${ACCOUNT_STATE_DIR}")
             mv "${BASE_DIR_TEMP}" "${ACCOUNT_STATE_DIR}"
         fi
-
-    # TODO(mfl): 03/02/2020 Remove the following code once its confirmed its redundant
-    # From the Jenkins logs it throws errors when TENANT is non-empty which makes sense
-    # as BASE_DIR_TEMP has been cleared by processing of the ACCOUNT. However sometimes
-    # it doesn't which suggests that it either is blank or contains a directory with an
-    # infrastructure subdirectory.
-    # Either way, without a temp dir to move, it seems unnecessary.
-    #    TENANT_INFRASTRUCTURE_DIR=$(findGen3TenantInfrastructureDir "${BASE_DIR}" "${TENANT}")
-    #    if [[ -z "${TENANT_INFRASTRUCTURE_DIR}" ]]; then
-    #
-    #        TENANT_INFRASTRUCTURE_DIR="${BASE_DIR}/${TENANT}"
-    #        mkdir -p $(filePath "${TENANT_INFRASTRUCTURE_DIR}")
-    #        mv "${BASE_DIR_TEMP}" "${TENANT_INFRASTRUCTURE_DIR}"
-    #    fi
-
     fi
 
     # Examine the structure and define key directories

--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -125,12 +125,6 @@ function options() {
 
   ENTRANCE_PARAMETERS="$(listFromArray "ENTRANCE_PARAMETERS_ARRAY" "||")"
 
-  # Ensure other mandatory arguments have been provided
-  if [[ (-z "${REQUEST_REFERENCE}") || (-z "${CONFIGURATION_REFERENCE}") ]]; then
-    fatalMandatory
-    return 1
-  fi
-
   # Input control for composite/CMDB input
   if [[ "${GENERATION_INPUT_SOURCE}" == "composite" || "${GENERATION_INPUT_SOURCE}" == "whatif" ]]; then
 
@@ -223,7 +217,7 @@ function options() {
         declare -ga "${composite}_array"
 
         # Legacy start fragments
-        for fragment in "${GENERATION_ENGINE_DIR}"/legacy/${composite}/start*.ftl; do
+        for fragment in "${GENERATION_ENGINE_DIR}"/legacy/${composite}/start.ftl; do
             $(inArray "${composite}_array" $(fileName "${fragment}")) && continue
             addToArray "${composite}_array" "${fragment}"
         done
@@ -250,7 +244,7 @@ function options() {
         done
 
         # Legacy end fragments
-        for fragment in ${GENERATION_ENGINE_DIR}/legacy/${composite}/*end.ftl; do
+        for fragment in ${GENERATION_ENGINE_DIR}/legacy/${composite}/end.ftl; do
             $(inArray "${composite}_array" $(fileName "${fragment}")) && continue
             addToArray "${composite}_array" "${fragment}"
         done
@@ -421,13 +415,13 @@ function process_template_pass() {
   done
 
   # Composites
-  [[ -f "${COMPOSITE_BLUEPRINT}" ]] && args+=("-v" "blueprint=${COMPOSITE_BLUEPRINT}")
-  [[ -f "${COMPOSITE_SETTINGS}" ]] && args+=("-v" "settings=${COMPOSITE_SETTINGS}")
-  [[ -f "${COMPOSITE_DEFINITIONS}" ]] && args+=("-v" "definitions=${COMPOSITE_DEFINITIONS}")
-  [[ -f "${COMPOSITE_STACK_OUTPUTS}" ]] && args+=("-v" "stackOutputs=${COMPOSITE_STACK_OUTPUTS}")
+  [[ -f "${COMPOSITE_BLUEPRINT}" ]]       && args+=("-v" "blueprint=${COMPOSITE_BLUEPRINT}")
+  [[ -f "${COMPOSITE_SETTINGS}" ]]        && args+=("-v" "settings=${COMPOSITE_SETTINGS}")
+  [[ -f "${COMPOSITE_DEFINITIONS}" ]]     && args+=("-v" "definitions=${COMPOSITE_DEFINITIONS}")
+  [[ -f "${COMPOSITE_STACK_OUTPUTS}" ]]   && args+=("-v" "stackOutputs=${COMPOSITE_STACK_OUTPUTS}")
 
   # Deployment Handling
-  [[ -n "${DEPLOYMENT_MODE}" ]] && args+=("-r" "deploymentMode=${DEPLOYMENT_MODE}")
+  [[ -n "${DEPLOYMENT_MODE}" ]]           && args+=("-r" "deploymentMode=${DEPLOYMENT_MODE}")
   [[ -n "${deployment_unit}" ]]           && args+=("-r" "deploymentUnit=${deployment_unit}")
   [[ -n "${deployment_group}" ]]          && args+=("-r" "deploymentGroup=${deployment_group}")
 
@@ -436,16 +430,16 @@ function process_template_pass() {
   [[ -n "${deployment_framework}" ]]      && args+=("-r" "deploymentFramework=${deployment_framework}")
 
   # Starting layers
-  [[ -n "${DISTRICT_TYPE}" ]] && args+=("-r" "districtType=${DISTRICT_TYPE}")
-  [[ -n "${TENANT}" ]] && args+=("-r" "tenant=${TENANT}")
-  [[ -n "${ACCOUNT}" ]] && args+=("-r" "account=${ACCOUNT}")
-  [[ -n "${region}" ]] && args+=("-r" "region=${region}")
-  [[ -n "${PRODUCT}" ]] && args+=("-r" "product=${PRODUCT}")
-  [[ -n "${ENVIRONMENT}" ]] && args+=("-r" "environment=${ENVIRONMENT}")
-  [[ -n "${SEGMENT}" ]] && args+=("-r" "segment=${SEGMENT}")
+  [[ -n "${DISTRICT_TYPE}" ]]             && args+=("-r" "districtType=${DISTRICT_TYPE}")
+  [[ -n "${TENANT}" ]]                    && args+=("-r" "tenant=${TENANT}")
+  [[ -n "${ACCOUNT}" ]]                   && args+=("-r" "account=${ACCOUNT}")
+  [[ -n "${region}" ]]                    && args+=("-r" "region=${region}")
+  [[ -n "${PRODUCT}" ]]                   && args+=("-r" "product=${PRODUCT}")
+  [[ -n "${ENVIRONMENT}" ]]               && args+=("-r" "environment=${ENVIRONMENT}")
+  [[ -n "${SEGMENT}" ]]                   && args+=("-r" "segment=${SEGMENT}")
 
   # Account Override
-  [[ -n "${account_region}" ]] && args+=("-r" "accountRegion=${account_region}")
+  [[ -n "${account_region}" ]]            && args+=("-r" "accountRegion=${account_region}")
 
   # Entrance parameters
   arrayFromList entranceParametersArray "${entrance_parameters}" "||"


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
<!--- Describe your changes in detail -->
- Checks that ACCOUNT or PRODUCT are defined before search settings
- Filters paths for account and product dirs based on ACCOUNT and PRODUCT names
- removes tenant infrastrucutre dir
- removes wildcard filter for end and start composite fragments 

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
- When searching for settings directories with the product not set ( for ACCOUNT districts) the settings assembly process would search and assemble all products settings when it didn't need to. 
- Wildcard on composite fragment fixes - fixes https://github.com/hamlet-io/engine/issues/963 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

