### PR TITLE
feat: detect existing images

### DIFF
--- a/automation/jenkins/aws/manageImages.sh
+++ b/automation/jenkins/aws/manageImages.sh
@@ -232,7 +232,11 @@ function main() {
 
                     if [[ -d "${USER_IMAGE}" ]]; then
                         pushd "${USER_IMAGE}" > /dev/null
-                        zip -r "${IMAGE_FILE}" *
+                        if [[ -f "${IMAGE_FILENAME}" ]]; then
+                            cp "${IMAGE_FILENAME}" "${IMAGE_FILE}"
+                        else
+                            zip -r "${IMAGE_FILE}" *
+                        fi
                         popd > /dev/null
                     fi
                 else


### PR DESCRIPTION

## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
If an image path to a directory is provided when uploading images, first check if the directory already contains the required image.

If it does, use that, otherwise zip the directory.

## Motivation and Context
This minimises the possibility of a double zip due to misconfiguration.

## How Has This Been Tested
Difficult to test locally - will test with an affected customer config once merged.

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

