### PR TITLE
refactor: Add deprecation warnings for bash executor

### DIFF
--- a/automation/jenkins/aws/acceptRelease.sh
+++ b/automation/jenkins/aws/acceptRelease.sh
@@ -4,6 +4,9 @@
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 # Ensure mandatory arguments have been provided
 [[ (-z "${RELEASE_MODE}") ||
     (-z "${RELEASE_TAG}") ]] && fatalMandatory

--- a/automation/jenkins/aws/acceptReleaseSetup.sh
+++ b/automation/jenkins/aws/acceptReleaseSetup.sh
@@ -4,8 +4,9 @@
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 # Get all the deployment unit commit information
 ${AUTOMATION_DIR}/manageBuildReferences.sh -f
 RESULT=$?
-
-

--- a/automation/jenkins/aws/backup.sh
+++ b/automation/jenkins/aws/backup.sh
@@ -4,6 +4,9 @@
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 . "${GENERATION_BASE_DIR}/execution/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 # Formulate parameters - any provided to this script are also passed trhough
 SNAPSHOT_OPTS=
 if [[ -n "${SNAPSHOT_COUNT}" ]]; then

--- a/automation/jenkins/aws/buildContentModelBender.sh
+++ b/automation/jenkins/aws/buildContentModelBender.sh
@@ -4,13 +4,16 @@
 trap '[[ (-z "${AUTOMATION_DEBUG}") ; exit 1' SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 dockerstagedir="$(getTempDir "cota_docker_XXXXXX" "${DOCKER_STAGE_DIR}")"
 chmod a+rwx "${dockerstagedir}"
 
 function main() {
   # Make sure we are in the build source directory
   cd ${AUTOMATION_BUILD_SRC_DIR}
-  
+
   # Create Build folders for Jenkins Permissions
   mkdir -p ${AUTOMATION_BUILD_SRC_DIR}/stage
   mkdir -p "${dockerstagedir}/indir"
@@ -18,7 +21,7 @@ function main() {
 
   cp -r "${AUTOMATION_BUILD_SRC_DIR}"/* "${dockerstagedir}/indir/"
 
-  # run Model Bender build using Docker Build image 
+  # run Model Bender build using Docker Build image
   info "Running ModelBender enterprise tasks..."
   docker run --rm \
     --volume="${dockerstagedir}/indir:/work/indir" \
@@ -35,11 +38,10 @@ function main() {
   cd "${dockerstagedir}/stage"
 
   mkdir -p "${AUTOMATION_BUILD_SRC_DIR}/dist"
-  zip -r "${AUTOMATION_BUILD_SRC_DIR}/dist/contentnode.zip" * 
+  zip -r "${AUTOMATION_BUILD_SRC_DIR}/dist/contentnode.zip" *
 
   # All good
   return 0
 }
 
 main "$@"
-

--- a/automation/jenkins/aws/buildContentStatic.sh
+++ b/automation/jenkins/aws/buildContentStatic.sh
@@ -4,16 +4,19 @@
 trap '[[ (-z "${AUTOMATION_DEBUG}") ; exit 1' SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 function main() {
   # Make sure we are in the build source directory
   cd ${AUTOMATION_BUILD_SRC_DIR}
-  
+
   # packge for content node
   if [[ -d "${AUTOMATION_BUILD_SRC_DIR}" ]]; then
     mkdir -p "${AUTOMATION_BUILD_SRC_DIR}/dist"
-    
+
     cd "${AUTOMATION_BUILD_SRC_DIR}"
-    zip -r "${AUTOMATION_BUILD_SRC_DIR}/dist/contentnode.zip" * 
+    zip -r "${AUTOMATION_BUILD_SRC_DIR}/dist/contentnode.zip" *
 
   fi
 
@@ -22,4 +25,3 @@ function main() {
 }
 
 main "$@"
-

--- a/automation/jenkins/aws/buildInfraDocs.sh
+++ b/automation/jenkins/aws/buildInfraDocs.sh
@@ -4,6 +4,9 @@
 trap '[[ (-z "${AUTOMATION_DEBUG}") ; exit 1' SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 tmpdir="$(getTempDir "cota_inf_XXX")"
 dockerstagedir="$(getTempDir "cota_docker_XXXXXX" "${DOCKER_STAGE_DIR}")"
 chmod a+rwx "${dockerstagedir}"
@@ -11,8 +14,8 @@ chmod a+rwx "${dockerstagedir}"
 function main() {
   # Make sure we are in the build source directory
   cd ${AUTOMATION_BUILD_SRC_DIR}
-  
-  # Unless specified use the latest InfraDocs version 
+
+  # Unless specified use the latest InfraDocs version
   if [[ -z "${INFRADOCS_VERSION}" ]]; then
     INFRADOCS_VERSION=latest
   fi
@@ -20,14 +23,14 @@ function main() {
   # Default Document for generation testing
   if [[ -z "${JEKYLL_DEFAULT_PAGE}" ]]; then
     JEKYLL_DEFAULT_PAGE=index.html
-  fi 
+  fi
 
-  # Default Timezone 
+  # Default Timezone
   if [[ -z "${JEKYLL_TIMEZONE}" ]]; then
     JEKYLL_TIMEZONE="Australia/Sydney"
   fi
 
-  # Default build Env 
+  # Default build Env
   if [[ -z "${JEKYLL_ENV}" ]]; then
     JEKYLL_ENV="production"
   fi
@@ -38,7 +41,7 @@ function main() {
 
   mkdir -p ${tmpdir}/_site
 
-  # run Jekyll build using Docker Build image 
+  # run Jekyll build using Docker Build image
   info "Running Jeykyll build"
 
   mkdir -p "${dockerstagedir}/indir"
@@ -50,21 +53,21 @@ function main() {
     --env TZ="${JEKYLL_TIMEZONE}" \
     --volume="${dockerstagedir}/indir:/indir" \
     --volume="${dockerstagedir}/outdir:/outdir" \
-    codeontap/infradocs:"${INFRADOCS_VERSION}" 
+    codeontap/infradocs:"${INFRADOCS_VERSION}"
 
   # Package for spa if required
   if [[ -f "${dockerstagedir}/outdir/${JEKYLL_DEFAULT_PAGE}" ]]; then
-    
+
     cd "${dockerstagedir}/outdir"
 
     mkdir -p "${AUTOMATION_BUILD_SRC_DIR}/dist"
-    zip -r "${AUTOMATION_BUILD_SRC_DIR}/dist/spa.zip" * 
-    
-  else 
+    zip -r "${AUTOMATION_BUILD_SRC_DIR}/dist/spa.zip" *
+
+  else
 
     fatal "No default page avaialable"
     return 1
-  
+
   fi
 
   # All good

--- a/automation/jenkins/aws/buildJS.sh
+++ b/automation/jenkins/aws/buildJS.sh
@@ -3,6 +3,8 @@
 trap '[[ (-z "${AUTOMATION_DEBUG}") && (-d "${NVM_DIR}") ]] && nvm deactivate; rm -rf "${NVM_DIR}" ; exit $?' SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
 
 function runTask() {
     local REQUIRED_TASK=$1; shift

--- a/automation/jenkins/aws/buildJekyll.sh
+++ b/automation/jenkins/aws/buildJekyll.sh
@@ -4,6 +4,9 @@
 trap '[[ (-z "${AUTOMATION_DEBUG}") ; exit 1' SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 dockerstagedir="$(getTempDir "cota_docker_XXXXXX" "${DOCKER_STAGE_DIR}")"
 chmod a+rwx "${dockerstagedir}"
 

--- a/automation/jenkins/aws/buildLaravel.sh
+++ b/automation/jenkins/aws/buildLaravel.sh
@@ -4,6 +4,9 @@
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 cd laravel/
 
 /usr/local/bin/composer install --prefer-source --no-interaction

--- a/automation/jenkins/aws/buildMeteor.sh
+++ b/automation/jenkins/aws/buildMeteor.sh
@@ -4,6 +4,9 @@
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 # Change to the app directory
 cd app
 

--- a/automation/jenkins/aws/buildNode.sh
+++ b/automation/jenkins/aws/buildNode.sh
@@ -4,6 +4,9 @@
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 # Make sure we are in the build source directory
 cd ${AUTOMATION_BUILD_SRC_DIR}
 

--- a/automation/jenkins/aws/buildOpenapi.sh
+++ b/automation/jenkins/aws/buildOpenapi.sh
@@ -6,6 +6,9 @@
 trap '[[ (-z "${AUTOMATION_DEBUG}") && (-d "${tmpdir}") ]] && rm -rf "${tmpdir}";exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 # Determine the registry - it impacts some file names
 IMAGE_FORMATS_ARRAY=(${IMAGE_FORMATS_LIST})
 REGISTRY_TYPE="${IMAGE_FORMATS_ARRAY[0]}"

--- a/automation/jenkins/aws/buildPython.sh
+++ b/automation/jenkins/aws/buildPython.sh
@@ -4,6 +4,9 @@
 trap '[[ (-z "${AUTOMATION_DEBUG}") && (-d "${venv_dir}") ]] && rm -rf "${venv_dir}"; exit 1' SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 function main() {
   # Make sure we are in the build source directory
   cd ${AUTOMATION_BUILD_SRC_DIR}
@@ -232,4 +235,3 @@ function main() {
 }
 
 main "$@"
-

--- a/automation/jenkins/aws/buildRDSSnapshot.sh
+++ b/automation/jenkins/aws/buildRDSSnapshot.sh
@@ -3,6 +3,9 @@
 trap '[[ (-z "${AUTOMATION_DEBUG}") ; exit 1' SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 function main() {
 
     tmpdir="$(getTempDir "cota_inf_XXX")"

--- a/automation/jenkins/aws/buildSPAStatic.sh
+++ b/automation/jenkins/aws/buildSPAStatic.sh
@@ -5,19 +5,21 @@
 trap '[[ (-z "${AUTOMATION_DEBUG}") ; exit 1' SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 function main() {
   # Make sure we are in the build source directory
   cd ${AUTOMATION_BUILD_SRC_DIR}
-  
+
   # packge for content node
   mkdir -p "${AUTOMATION_BUILD_SRC_DIR}/dist"
-    
+
   cd "${AUTOMATION_BUILD_SRC_DIR}"
-  zip -r "${AUTOMATION_BUILD_SRC_DIR}/dist/spa.zip" * 
+  zip -r "${AUTOMATION_BUILD_SRC_DIR}/dist/spa.zip" *
 
   # All good
   return 0
 }
 
 main "$@"
-

--- a/automation/jenkins/aws/buildScripts.sh
+++ b/automation/jenkins/aws/buildScripts.sh
@@ -4,17 +4,20 @@
 trap '[[ (-z "${AUTOMATION_DEBUG}") ; exit 1' SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 tmpdir="$(getTempDir "cota_inf_XXX")"
 
 function main() {
     # Make sure we are in the build source directory
     cd ${AUTOMATION_BUILD_SRC_DIR}
-    
+
     # Mkae sure we have a script to start from
     [[ ! -f init.sh ]] &&
         { fatal "No init.sh found - this is the entry point for this build type"; return 1; }
 
-    zip -r "${tmpdir}/scripts.zip" * 
+    zip -r "${tmpdir}/scripts.zip" *
 
     if [[ -f ${tmpdir}/scripts.zip ]]; then
         mkdir "${AUTOMATION_BUILD_SRC_DIR}/dist"

--- a/automation/jenkins/aws/buildSetup.sh
+++ b/automation/jenkins/aws/buildSetup.sh
@@ -4,6 +4,9 @@
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 # Ensure we are in the directory where the repo was checked out
 cd ${AUTOMATION_BUILD_DIR}
 

--- a/automation/jenkins/aws/buildSwagger.sh
+++ b/automation/jenkins/aws/buildSwagger.sh
@@ -3,6 +3,9 @@
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 
+# DEPRECATED
+deprecated_script
+
 # All the logic is in the openapi build
 ${AUTOMATION_DIR}/buildOpenapi.sh "$@"
 RESULT=$?

--- a/automation/jenkins/aws/buildTenantBlueprints.sh
+++ b/automation/jenkins/aws/buildTenantBlueprints.sh
@@ -4,6 +4,9 @@
 trap '[[ (-z "${AUTOMATION_DEBUG}") ; exit 1' SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 # Usage - This script should be called from the directory where a generated blueprint is stored.
 # This would ideally be tirggered using a git hook from an automation server
 
@@ -20,43 +23,42 @@ function main() {
 
     ${AUTOMATION_DIR}/manageRepo.sh -c -l "blueprint consolidation" \
         -n "${AUTOMATION_REGISTRY_REPO}" -v "${ACCOUNT_GIT_PROVIDER}" \
-        -d "${BLUEPRINT_CONSOLIDATION_DIR}" 
+        -d "${BLUEPRINT_CONSOLIDATION_DIR}"
 
     if [[ -n "${INFRADOCS_PREFIX}" ]]; then
         local BLUEPRINT_CONSOLIDATION_DIR="${AUTOMATION_BUILD_SRC_DIR}/registry/"
-    fi 
+    fi
 
     local BLUEPRINT_DESTINATION_DIR="${BLUEPRINT_CONSOLIDATION_DIR}/blueprints/content"
     local BLUEPRINT_DESTINATION_FILE="${BLUEPRINT_DESTINATION_DIR}/${TENANT}-${PRODUCT}-${ENVIRONMENT}-${SEGMENT}-blueprint.json"
 
     info "blueprint repo ${BLUEPRINT_DESTINATION_DIR}"
 
-    if [[ -f "${AUTOMATION_BUILD_SRC_DIR}/blueprint.json" ]]; then 
+    if [[ -f "${AUTOMATION_BUILD_SRC_DIR}/blueprint.json" ]]; then
 
-        if [[ ! -d "${BLUEPRINT_DESTINATION_DIR}" ]]; then 
+        if [[ ! -d "${BLUEPRINT_DESTINATION_DIR}" ]]; then
             mkdir -p "${BLUEPRINT_DESTINATION_DIR}"
-        fi 
+        fi
 
         echo "Adding Blueprint to Tenant Infrastructure..."
         cp "${AUTOMATION_BUILD_SRC_DIR}/blueprint.json" "${BLUEPRINT_DESTINATION_FILE}"
-    
+
     else
 
-        if [[ -f "${BLUEPRINT_DESTINATION_FILE}" ]]; then 
+        if [[ -f "${BLUEPRINT_DESTINATION_FILE}" ]]; then
             echo "Removing Blueprint from Tenant Infrastructure..."
             rm "${BLUEPRINT_DESTINATION_FILE}"
-        fi 
+        fi
     fi
 
     DETAIL_MESSAGE="${DETAIL_MESSAGE}, blueprint consolidation"
     ${AUTOMATION_DIR}/manageRepo.sh -p \
         -d "${BLUEPRINT_CONSOLIDATION_DIR}" \
         -l "blueprint consolidation" \
-        -m "${DETAIL_MESSAGE}" 
+        -m "${DETAIL_MESSAGE}"
 
   # All good
   return 0
 }
 
 main "$@"
-

--- a/automation/jenkins/aws/confirmBuilds.sh
+++ b/automation/jenkins/aws/confirmBuilds.sh
@@ -4,6 +4,9 @@
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 # Ensure mandatory arguments have been provided
 [[ (-z "${RELEASE_MODE}") ||
     (-z "${ACCEPTANCE_TAG}") ]] && fatalMandatory

--- a/automation/jenkins/aws/constructTree.sh
+++ b/automation/jenkins/aws/constructTree.sh
@@ -3,5 +3,8 @@
 [[ -n "${AUTOMATION_DEBUG}" ]] && set ${AUTOMATION_DEBUG}
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 
+# DEPRECATED
+deprecated_script
+
 ${AUTOMATION_BASE_DIR}/constructTree.sh "$@"
 RESULT=$?

--- a/automation/jenkins/aws/deploy.sh
+++ b/automation/jenkins/aws/deploy.sh
@@ -4,6 +4,9 @@
 trap 'exit 1' SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 function main() {
   # Add conventional commit details
   DETAIL_MESSAGE="${DETAIL_MESSAGE}, cctype=deploy, ccdesc=${AUTOMATION_JOB_IDENTIFIER}"

--- a/automation/jenkins/aws/deployRelease.sh
+++ b/automation/jenkins/aws/deployRelease.sh
@@ -4,6 +4,9 @@
 trap 'exit 1' SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 function main() {
   # Add conventional commit and deploy/release tag to details
   DETAIL_MESSAGE="deployment=${DEPLOYMENT_TAG}, release=${RELEASE_TAG}, ${DETAIL_MESSAGE}, cctype=deploy, ccdesc=${AUTOMATION_JOB_IDENTIFIER}"

--- a/automation/jenkins/aws/deploySetup.sh
+++ b/automation/jenkins/aws/deploySetup.sh
@@ -4,7 +4,9 @@
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 # Include the build information in the detail message
 ${AUTOMATION_DIR}/manageBuildReferences.sh -l
 RESULT=$?
-

--- a/automation/jenkins/aws/manageAccount.sh
+++ b/automation/jenkins/aws/manageAccount.sh
@@ -4,6 +4,9 @@
 trap 'exit 1' SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 function main() {
   # Add conventional commit details
   DETAIL_MESSAGE="${DETAIL_MESSAGE}, cctype=manacc, ccdesc=${AUTOMATION_JOB_IDENTIFIER}"

--- a/automation/jenkins/aws/manageDataSetRDSSnapshot.sh
+++ b/automation/jenkins/aws/manageDataSetRDSSnapshot.sh
@@ -6,4 +6,3 @@ trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 # Note that filename can still overridden via provided parameters
 ${AUTOMATION_DIR}/manageRdssnapshot.sh -y "rdssnapshot" "$@"
 RESULT=$?
-

--- a/automation/jenkins/aws/manageEnvironment.sh
+++ b/automation/jenkins/aws/manageEnvironment.sh
@@ -4,6 +4,9 @@
 trap 'exit 1' SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 function main() {
   # Add conventional commit details
   DETAIL_MESSAGE="${DETAIL_MESSAGE}, cctype=manenv, ccdesc=${AUTOMATION_JOB_IDENTIFIER}"
@@ -20,4 +23,3 @@ function main() {
 }
 
 main "$@"
-

--- a/automation/jenkins/aws/manageUnits.sh
+++ b/automation/jenkins/aws/manageUnits.sh
@@ -4,6 +4,10 @@
 trap 'exit 1' SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+
+# DEPRECATED
+deprecated_script
+
 #Defaults
 
 function usage() {

--- a/automation/jenkins/aws/plan.sh
+++ b/automation/jenkins/aws/plan.sh
@@ -4,6 +4,9 @@
 trap 'exit 1' SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 function main() {
 
     # Planning should only affect the state

--- a/automation/jenkins/aws/prepareRelease.sh
+++ b/automation/jenkins/aws/prepareRelease.sh
@@ -4,16 +4,19 @@
 trap 'exit 1' SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 function main() {
   # Update build references
   ${AUTOMATION_DIR}/manageBuildReferences.sh -u || return $?
-  
+
   # Create the templates
   ${AUTOMATION_DIR}/manageUnits.sh -l "application" -a "${DEPLOYMENT_UNIT_LIST}" -r "${RELEASE_TAG}" || return $?
-  
+
   # All ok so tag the config repo
   save_product_config "${DETAIL_MESSAGE}" "${PRODUCT_CONFIG_REFERENCE}" "${RELEASE_TAG}" || return $?
-  
+
   # Commit the generated application templates
   save_product_infrastructure "${DETAIL_MESSAGE}" "${PRODUCT_INFRASTRUCTURE_REFERENCE}" "${RELEASE_TAG}" || return $?
 

--- a/automation/jenkins/aws/prepareReleaseSetup.sh
+++ b/automation/jenkins/aws/prepareReleaseSetup.sh
@@ -4,6 +4,9 @@
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 # Add release number to details
 DETAIL_MESSAGE="release=${RELEASE_TAG}, ${DETAIL_MESSAGE}"
 save_context_property DETAIL_MESSAGE

--- a/automation/jenkins/aws/promoteRelease.sh
+++ b/automation/jenkins/aws/promoteRelease.sh
@@ -4,6 +4,9 @@
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 # Ensure mandatory arguments have been provided
 exit_on_invalid_environment_variables "RELEASE_MODE" "ACCEPTANCE_TAG"
 

--- a/automation/jenkins/aws/runLambda.sh
+++ b/automation/jenkins/aws/runLambda.sh
@@ -4,17 +4,20 @@
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 cd "${SEGMENT_SOLUTIONS_DIR}"
 
 ARGS=""
 
-if [[ -n "${LAMBDA_INCLUDE_LOGS}" ]]; then 
+if [[ -n "${LAMBDA_INCLUDE_LOGS}" ]]; then
     ARGS="${ARGS} -l"
 fi
 
 if [[ -n "${LAMBDA_INPUT_PAYLOAD}" ]]; then
     ARGS="${ARGS} -i \"${LAMBDA_INPUT_PAYLOAD}\""
-fi 
+fi
 
 # run the required tasks
 ${GENERATION_DIR}/runLambda.sh -u "${LAMBDA_DEPLOYMENT_UNIT}" -f "${LAMBDA_FUNCTION_ID}" "${ARGS}"

--- a/automation/jenkins/aws/runTasks.sh
+++ b/automation/jenkins/aws/runTasks.sh
@@ -4,6 +4,9 @@
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 cd "${SEGMENT_SOLUTIONS_DIR}"
 
 # Build up the additional enviroment variables required

--- a/automation/jenkins/aws/updateBuildReference.sh
+++ b/automation/jenkins/aws/updateBuildReference.sh
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
 
+# DEPRECATED
+deprecated_script
+
 ${AUTOMATION_DIR}/updateBuildReferences.sh

--- a/automation/jenkins/aws/updateBuildReferences.sh
+++ b/automation/jenkins/aws/updateBuildReferences.sh
@@ -4,6 +4,9 @@
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 # Update build references
 ${AUTOMATION_DIR}/manageBuildReferences.sh -u
 RESULT=$? && [[ ${RESULT} -ne 0 ]] && exit
@@ -29,5 +32,3 @@ save_chain_property DEPLOYMENT_UNITS "${DEPLOYMENT_UNIT_LIST}"
 
 # All good
 RESULT=0
-
-

--- a/automation/jenkins/aws/validateAcceptReleaseParameters.sh
+++ b/automation/jenkins/aws/validateAcceptReleaseParameters.sh
@@ -4,6 +4,9 @@
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 # Ensure RELEASE_IDENTIFIER have been provided
 [[ -z "${RELEASE_IDENTIFIER}" ]] &&
     fatal "Job requires the identifier of the release to be accepted" && exit
@@ -12,5 +15,3 @@ trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 
 # All good
 RESULT=0
-
-

--- a/automation/jenkins/aws/validateDeployReleaseParameters.sh
+++ b/automation/jenkins/aws/validateDeployReleaseParameters.sh
@@ -4,6 +4,9 @@
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 # Ensure RELEASE_IDENTIFIER have been provided
 [[ -z "${RELEASE_IDENTIFIER}" ]] &&
     fatal "Job requires the identifier of the release to use in the deployment" && exit
@@ -16,4 +19,3 @@ trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 
 # All good
 RESULT=0
-

--- a/automation/jenkins/aws/validateUpdateBuildReferenceParameters.sh
+++ b/automation/jenkins/aws/validateUpdateBuildReferenceParameters.sh
@@ -4,6 +4,9 @@
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 [[ ( -z "${CODE_COMMIT_LIST}" ) && ( -z "${CODE_TAG_LIST}" ) ]] &&
     fatal "This job requires a GIT_COMMIT or a DEPLOYMENT_UNIT! value" && exit
 
@@ -13,6 +16,3 @@ trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 
 # All good
 RESULT=0
-
-
-

--- a/automation/jenkins/aws/validateUpdateBuildReferencesParameters.sh
+++ b/automation/jenkins/aws/validateUpdateBuildReferencesParameters.sh
@@ -4,6 +4,9 @@
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 . "${AUTOMATION_BASE_DIR}/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 [[ ( -z "${CODE_COMMIT_LIST}" ) && ( -z "${CODE_TAG_LIST}" ) ]] &&
     fatal "This job requires a GIT_COMMIT or a DEPLOYMENT_UNIT! value" && exit
 
@@ -13,6 +16,3 @@ trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 
 # All good
 RESULT=0
-
-
-

--- a/cli/createBlueprint.sh
+++ b/cli/createBlueprint.sh
@@ -4,6 +4,9 @@
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 . "${GENERATION_BASE_DIR}/execution/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 function options() {
 
   # Parse options

--- a/cli/createBuildblueprint.sh
+++ b/cli/createBuildblueprint.sh
@@ -4,6 +4,9 @@
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 . "${GENERATION_BASE_DIR}/execution/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 function options() {
 
   # Parse options

--- a/cli/createSSLCertificateRequest.sh
+++ b/cli/createSSLCertificateRequest.sh
@@ -2,6 +2,9 @@
 
 # Trigger the creation of a CSR
 
+# DEPRECATED
+deprecated_script
+
 certificate_name="$1"; shift
 cn="$1"; shift
 san="$1"; shift

--- a/cli/integrator/manageCredentials.sh
+++ b/cli/integrator/manageCredentials.sh
@@ -4,6 +4,9 @@
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 . "${GENERATION_BASE_DIR}/execution/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 # Defaults
 CREDENTIAL_PATH_DEFAULT="root+aws"
 CREDENTIAL_TYPE_DEFAULT="Login"

--- a/cli/manageCredentialCrypto.sh
+++ b/cli/manageCredentialCrypto.sh
@@ -4,6 +4,9 @@
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 . "${GENERATION_BASE_DIR}/execution/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 BASE64_REGEX="^[A-Za-z0-9+/=\n]\+$"
 
 # Defaults

--- a/cli/manageCrypto.sh
+++ b/cli/manageCrypto.sh
@@ -4,6 +4,10 @@
 trap '. ${GENERATION_BASE_DIR}/execution/cleanupContext.sh; exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 . "${GENERATION_BASE_DIR}/execution/common.sh"
 
+
+# DEPRECATED
+deprecated_script
+
 BASE64_REGEX="^[A-Za-z0-9+/=\n]\+$"
 
 # Defaults

--- a/cli/manageFileCrypto.sh
+++ b/cli/manageFileCrypto.sh
@@ -4,6 +4,9 @@
 trap 'exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 . "${GENERATION_BASE_DIR}/execution/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 # Defaults
 
 function usage() {

--- a/cli/manageSSLCertificate.sh
+++ b/cli/manageSSLCertificate.sh
@@ -4,6 +4,10 @@
 trap '. ${GENERATION_BASE_DIR}/execution/cleanupContext.sh; exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 . "${GENERATION_BASE_DIR}/execution/common.sh"
 
+
+# DEPRECATED
+deprecated_script
+
 CERTIFICATE_OPERATION_LIST="list"
 CERTIFICATE_OPERATION_DELETE="delete"
 CERTIFICATE_OPERATION_UPLOAD="upload"

--- a/cli/rebootRDSDatabase.sh
+++ b/cli/rebootRDSDatabase.sh
@@ -4,6 +4,9 @@
 trap '. ${GENERATION_BASE_DIR}/execution/cleanupContext.sh; exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 . "${GENERATION_BASE_DIR}/execution/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 # Defaults
 DELAY_DEFAULT=30
 TIER_DEFAULT="database"

--- a/cli/runLambda.sh
+++ b/cli/runLambda.sh
@@ -4,6 +4,8 @@
 trap '. ${GENERATION_BASE_DIR}/execution/cleanupContext.sh; exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 . "${GENERATION_BASE_DIR}/execution/common.sh"
 
+# DEPRECATED
+deprecated_script
 
 #Defaults
 INCLUDE_LOG_TAIL_DEFAULT="true"

--- a/cli/runTask.sh
+++ b/cli/runTask.sh
@@ -4,6 +4,9 @@
 trap '. ${GENERATION_BASE_DIR}/execution/cleanupContext.sh; exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 . "${GENERATION_BASE_DIR}/execution/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 # Defaults
 DELAY_DEFAULT=30
 RETRY_COUNT_DEFAULT=120

--- a/cli/snapshotRDSDatabase.sh
+++ b/cli/snapshotRDSDatabase.sh
@@ -4,6 +4,9 @@
 trap '. ${GENERATION_BASE_DIR}/execution/cleanupContext.sh; exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 . "${GENERATION_BASE_DIR}/execution/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 # Defaults
 TIER_DEFAULT="database"
 

--- a/cli/updateObjectACL.sh
+++ b/cli/updateObjectACL.sh
@@ -4,6 +4,9 @@
 trap '. ${GENERATION_BASE_DIR}/execution/cleanupContext.sh; exit ${RESULT:-1}' EXIT SIGHUP SIGINT SIGTERM
 . "${GENERATION_BASE_DIR}/execution/common.sh"
 
+# DEPRECATED
+deprecated_script
+
 # Defaults
 ACL_DEFAULT="private"
 PREFIX_DEFAULT="/"

--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -292,7 +292,7 @@ function log_write_event() {
 
 function deprecated_script() {
   warn ""
-  warn "The script ${caller} has been depreated and will be removed in the next release \n See https://docs.hamlet.io/blog for details on the replacement"
+  warn "The script ${caller} has been deprecated and will be removed in the next major release \n See https://docs.hamlet.io/blog for details on the replacement"
   warn ""
 }
 

--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -288,6 +288,14 @@ function log_write_event() {
     done
 }
 
+# -- Deprecation Handling
+
+function deprecated_script() {
+  warn ""
+  warn "The script ${caller} has been depreated and will be removed in the next release \n See https://docs.hamlet.io/blog for details on the replacement"
+  warn ""
+}
+
 # -- String manipulation --
 
 function join() {


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
<!--- Describe your changes in detail -->
- Adds warning on scripts that will be deprecated on the next release of hamlet

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The scripts included in the deprecation process have been superseded by a range of features now included within the hamlet python cli. As a result these scripts should no longer be required 

- Runbooks within the cli and engine should essentially replace the run* scripts and allow for more flexible, simplified control over how tasks can be executed on the deployments 
- build* scripts have been deprecated in favour of removing this feature from hamlet and make the image/artefact the starting point of code for hamlet 
- The release management has been consolidated into a set of standardised commands which should be flexible enough to fit into users release processes, rather than having us dictate the process. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
This is the inttial setup of the warning message which has been tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

