### PR TITLE
feat: add stackoutput entrance support

### DIFF
--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -429,6 +429,9 @@ function process_template_pass() {
   [[ -n "${providers}" ]]                 && args+=("-r" "providers=${providers}")
   [[ -n "${deployment_framework}" ]]      && args+=("-r" "deploymentFramework=${deployment_framework}")
 
+  # CMDB Root
+  [[ -n "${ROOT_DIR}" ]]                  && args+=("-r" "rootDir=${ROOT_DIR}")
+
   # Starting layers
   [[ -n "${DISTRICT_TYPE}" ]]             && args+=("-r" "districtType=${DISTRICT_TYPE}")
   [[ -n "${TENANT}" ]]                    && args+=("-r" "tenant=${TENANT}")
@@ -719,6 +722,38 @@ function process_template() {
 
         *)
           local cf_dir_default="${PRODUCT_STATE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"
+          cleanup_level="${deployment_group}"
+          ;;
+      esac
+      ;;
+
+    stackoutput)
+      case "${deployment_group}" in
+        account)
+          local cf_dir_default="${ACCOUNT_STATE_DIR}/stackoutput/shared"
+          ;;
+
+        product)
+          local cf_dir_default="${PRODUCT_STATE_DIR}/stackoutput/shared"
+          ;;
+
+        application)
+          local cf_dir_default="${PRODUCT_STATE_DIR}/stackoutput/${ENVIRONMENT}/${SEGMENT}"
+          cleanup_level="app"
+          ;;
+
+        solution)
+          local cf_dir_default="${PRODUCT_STATE_DIR}/stackoutput/${ENVIRONMENT}/${SEGMENT}"
+          cleanup_level="soln"
+          ;;
+
+        segment)
+          local cf_dir_default="${PRODUCT_STATE_DIR}/stackoutput/${ENVIRONMENT}/${SEGMENT}"
+          cleanup_level="seg"
+          ;;
+
+        *)
+          local cf_dir_default="${PRODUCT_STATE_DIR}/stackoutput/${ENVIRONMENT}/${SEGMENT}"
           cleanup_level="${deployment_group}"
           ;;
       esac


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds file path handling for the stackotput generated file
- Adds a stackoutput directory within the state dir to avoid generation overrides of the files
- Adds the ROOT_DIR as a parameter to the engine calls

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Allows for the engine to generate it's own stack outputs as required

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

