### PR TITLE
feat: handle the migration to occurrence based deployments everywhere

### DIFF
--- a/cli/createTemplate.sh
+++ b/cli/createTemplate.sh
@@ -151,14 +151,14 @@ function options() {
     else
       debug "Using CMDB composites"
 
-      if [[ -n "${DEPLOYMENT_GROUP}" ]]; then
-        case "${DEPLOYMENT_GROUP}" in
+      if [[ -n "${DISTRICT_TYPE}" ]]; then
+        case "${DISTRICT_TYPE}" in
           account)
             [[ -z "${ACCOUNT_DIR}" ]] &&
               fatalLocation "Could not find ACCOUNT_DIR directory for account: \"${ACCOUNT}\"" && return 1
             ;;
 
-          *)
+          segment)
             [[ -z "${SEGMENT_SOLUTIONS_DIR}" ]] &&
               fatalLocation "Cound not find SEGMENT_SOLUTIONS_DIR directory for segment \"${SEGMENT}\"" && return 1
             ;;
@@ -669,13 +669,14 @@ function process_template_pass() {
 }
 
 function process_template() {
-  local entrance="${1,,}"; shift
-  local flows="${1,,}"; shift
-  local deployment_unit="${1,,}"; shift
-  local deployment_group="${1,,}"; shift
-  local account="$1"; shift
-  local account_region="${1,,}"; shift
-  local region="${1,,}"; shift
+  local entrance="${1}"; shift
+  local flows="${1}"; shift
+  local district_type="${1}"; shift
+  local deployment_unit="${1}"; shift
+  local deployment_group="${1}"; shift
+  local account="${1}"; shift
+  local account_region="${1}"; shift
+  local region="${1}"; shift
   local request_reference="${1}"; shift
   local configuration_reference="${1}"; shift
   local deployment_mode="${1}"; shift
@@ -686,47 +687,42 @@ function process_template() {
   local template_alternatives=("primary")
   local cleanup_level="${deployment_group}"
 
-  case "${entrance}" in
+  case "${district_type}" in
+    account)
+      local cf_dir_default="${ACCOUNT_STATE_DIR}/cf/shared"
+      ;;
 
+    segment)
+      local cf_dir_default="${PRODUCT_STATE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"
+      ;;
+  esac
+
+
+  case "${entrance}" in
     schema)
       local cf_dir_default="${PRODUCT_STATE_DIR}/hamlet"
       ;;
 
     deployment)
       case "${deployment_group}" in
-        account)
-          local cf_dir_default="${ACCOUNT_STATE_DIR}/cf/shared"
-          ;;
-
-        product)
-          local cf_dir_default="${PRODUCT_STATE_DIR}/cf/shared"
-          ;;
-
         application)
-          local cf_dir_default="${PRODUCT_STATE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"
           cleanup_level="app"
           ;;
 
         solution)
-          local cf_dir_default="${PRODUCT_STATE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"
           cleanup_level="soln"
           ;;
 
         segment)
-          local cf_dir_default="${PRODUCT_STATE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"
           cleanup_level="seg"
           ;;
 
         *)
-          local cf_dir_default="${PRODUCT_STATE_DIR}/cf/${ENVIRONMENT}/${SEGMENT}"
           cleanup_level="${deployment_group}"
           ;;
       esac
       ;;
 
-    *)
-      local cf_dir_default="${PRODUCT_STATE_DIR}/hamlet/${ENVIRONMENT}/${SEGMENT}"
-      ;;
   esac
 
   # Handle >=v2.0.1 cmdb where du/placement subdirectories were introduced for state
@@ -990,6 +986,7 @@ function main() {
   process_template \
     "${ENTRANCE}" \
     "${FLOWS}" \
+    "${DISTRICT_TYPE}" \
     "${DEPLOYMENT_UNIT}" "${DEPLOYMENT_GROUP}" \
     "${ACCOUNT}" "${ACCOUNT_REGION}" \
     "${REGION}" \


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- template and stack processing to use the district_type to split between account and segment
- Removes older stack handling which is no longer in use 
- Removes support for product and multi deployments which aren't supported in the engine and will be added back in as required

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This allows for occurrence based deployments to be completed in account and segment level districts to extend the control over how resources are deployed 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

