### PR TITLE
feat: support cliv2 kms encrypt

### DIFF
--- a/cli/manageCrypto.sh
+++ b/cli/manageCrypto.sh
@@ -342,7 +342,7 @@ function main() {
     # Perform the operation
     case ${CRYPTO_OPERATION} in
         encrypt)
-            cli_v1="$(awsv1 --version | grep 'aws-cli/1.')"
+            cli_v1="$(aws --version | grep 'aws-cli/1.')"
             if [[ -n "$cli_v1" ]] ; then
                 cli_encrypt="kms encrypt"
             else

--- a/cli/manageCrypto.sh
+++ b/cli/manageCrypto.sh
@@ -342,7 +342,14 @@ function main() {
     # Perform the operation
     case ${CRYPTO_OPERATION} in
         encrypt)
-            CRYPTO_TEXT=$(cd "${tmp_dir}"; aws --region ${REGION} --output text kms encrypt \
+            cli_v1=$(awsv1 --version | grep "aws-cli/1.")
+            if [ -n "$cli_v1" ] ; then
+                cli_encrypt="kms encrypt"
+            else
+                cli_encrypt="kms encrypt --cli-binary-format raw-in-base64-out"
+            fi
+
+            CRYPTO_TEXT=$(cd "${tmp_dir}"; aws --region ${REGION} --output text ${cli_encrypt} \
                 --key-id "${KEYID}" --query CiphertextBlob \
                 --plaintext "fileb://ciphertext.bin")
             ;;

--- a/cli/manageCrypto.sh
+++ b/cli/manageCrypto.sh
@@ -343,7 +343,7 @@ function main() {
     case ${CRYPTO_OPERATION} in
         encrypt)
             cli_v1="$(awsv1 --version | grep 'aws-cli/1.')"
-            if [ -n "$cli_v1" ] ; then
+            if [[ -n "$cli_v1" ]] ; then
                 cli_encrypt="kms encrypt"
             else
                 cli_encrypt="kms encrypt --cli-binary-format raw-in-base64-out"

--- a/cli/manageCrypto.sh
+++ b/cli/manageCrypto.sh
@@ -342,7 +342,7 @@ function main() {
     # Perform the operation
     case ${CRYPTO_OPERATION} in
         encrypt)
-            cli_v1=$(awsv1 --version | grep "aws-cli/1.")
+            cli_v1="$(awsv1 --version | grep 'aws-cli/1.')"
             if [ -n "$cli_v1" ] ; then
                 cli_encrypt="kms encrypt"
             else

--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -1149,7 +1149,14 @@ function encrypt_kms_string() {
   local value="$1"; shift
   local kms_key_id="$1"; shift
 
-  aws --region "${region}" kms encrypt --key-id "${kms_key_id}" --plaintext "${value}" --query CiphertextBlob --output text
+  local cli_v1=$(awsv1 --version | grep "aws-cli/1.")
+  if [ -n "$cli_v1" ] ; then
+    local cli_encrypt="kms encrypt"
+  else
+    local cli_encrypt="kms encrypt --cli-binary-format raw-in-base64-out"
+  fi
+
+  aws --region "${region}" ${cli_encrypt} --key-id "${kms_key_id}" --plaintext "${value}" --query CiphertextBlob --output text
 }
 
 function encrypt_kms_file() {

--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -1150,7 +1150,7 @@ function encrypt_kms_string() {
   local kms_key_id="$1"; shift
 
   local cli_v1="$(awsv1 --version | grep 'aws-cli/1.')"
-  if [ -n "$cli_v1" ] ; then
+  if [[ -n "$cli_v1" ]] ; then
     local cli_encrypt="kms encrypt"
   else
     local cli_encrypt="kms encrypt --cli-binary-format raw-in-base64-out"
@@ -1170,7 +1170,7 @@ function encrypt_kms_file() {
   local return_status
 
   local cli_v1="$(awsv1 --version | grep 'aws-cli/1.')"
-  if [ -n "$cli_v1" ] ; then
+  if [[ -n "$cli_v1" ]] ; then
     local cli_encrypt="kms encrypt"
   else
     local cli_encrypt="kms encrypt --cli-binary-format raw-in-base64-out"

--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -1149,7 +1149,7 @@ function encrypt_kms_string() {
   local value="$1"; shift
   local kms_key_id="$1"; shift
 
-  local cli_v1=$(awsv1 --version | grep "aws-cli/1.")
+  local cli_v1="$(awsv1 --version | grep 'aws-cli/1.')"
   if [ -n "$cli_v1" ] ; then
     local cli_encrypt="kms encrypt"
   else
@@ -1169,10 +1169,17 @@ function encrypt_kms_file() {
   local tmp_dir="$(getTopTempDir)"
   local return_status
 
+  local cli_v1="$(awsv1 --version | grep 'aws-cli/1.')"
+  if [ -n "$cli_v1" ] ; then
+    local cli_encrypt="kms encrypt"
+  else
+    local cli_encrypt="kms encrypt --cli-binary-format raw-in-base64-out"
+  fi
+
   cp "${input_file}" "${tmp_dir}/encrypt_file" || return_status=255
 
   if [[ -z "${return_status}" ]]; then
-    (cd "${tmp_dir}"; aws --region "${region}" --output text kms encrypt \
+    (cd "${tmp_dir}"; aws --region "${region}" --output text ${cli_encrypt} \
       --key-id "${kms_key_id}" --query CiphertextBlob \
       --plaintext "fileb://encrypt_file" > "${output_file}"; return_status=$?)
   fi

--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -1169,7 +1169,7 @@ function encrypt_kms_file() {
   local tmp_dir="$(getTopTempDir)"
   local return_status
 
-  local cli_v1="$(awsv1 --version | grep 'aws-cli/1.')"
+  local cli_v1="$(aws --version | grep 'aws-cli/1.')"
   if [[ -n "$cli_v1" ]] ; then
     local cli_encrypt="kms encrypt"
   else

--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -1149,7 +1149,7 @@ function encrypt_kms_string() {
   local value="$1"; shift
   local kms_key_id="$1"; shift
 
-  local cli_v1="$(awsv1 --version | grep 'aws-cli/1.')"
+  local cli_v1="$(aws --version | grep 'aws-cli/1.')"
   if [[ -n "$cli_v1" ]] ; then
     local cli_encrypt="kms encrypt"
   else


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
Handle AWS CLIv2's requirement for the additional parameter of `--cli-binary-format raw-in-base64-out` for the way we use kms encrypt

## Motivation and Context
Caused a failure when upgrading Parks RDS

## How Has This Been Tested?
locally for `hamlet manage crypto`, but `hamlet deploy` doesn't seem to run the local "dev" executor utility.sh

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

