### PR TITLE
fix(expo): reinstate archive upload for sourcemaps

### DIFF
--- a/cli/runExpoAppPublish.sh
+++ b/cli/runExpoAppPublish.sh
@@ -476,18 +476,17 @@ function main() {
 
         fi
 
-        if [[ -n "${BUILD_REFERENCE}" ]]; then
-            info "Override revisionId to match the build reference ${BUILD_REFERENCE}"
-            jq -c --arg REVISION_ID "${BUILD_REFERENCE}" '.revisionId=$REVISION_ID' <"${SRC_PATH}/app/dist/build/${OTA_VERSION}/ios-index.json" >"${tmpdir}/ios-expo-override.json"
-            mv "${tmpdir}/ios-expo-override.json" "${SRC_PATH}/app/dist/build/${OTA_VERSION}/ios-index.json"
+        info "Override revisionId to match the build reference ${BUILD_REFERENCE}"
+        jq -c --arg REVISION_ID "${BUILD_REFERENCE}" '.revisionId=$REVISION_ID' <"${SRC_PATH}/app/dist/build/${OTA_VERSION}/ios-index.json" >"${tmpdir}/ios-expo-override.json"
+        mv "${tmpdir}/ios-expo-override.json" "${SRC_PATH}/app/dist/build/${OTA_VERSION}/ios-index.json"
 
-            jq -c --arg REVISION_ID "${BUILD_REFERENCE}" '.revisionId=$REVISION_ID' <"${SRC_PATH}/app/dist/build/${OTA_VERSION}/android-index.json" >"${tmpdir}/android-expo-override.json"
-            mv "${tmpdir}/android-expo-override.json" "${SRC_PATH}/app/dist/build/${OTA_VERSION}/android-index.json"
-        fi
+        jq -c --arg REVISION_ID "${BUILD_REFERENCE}" '.revisionId=$REVISION_ID' <"${SRC_PATH}/app/dist/build/${OTA_VERSION}/android-index.json" >"${tmpdir}/android-expo-override.json"
+        mv "${tmpdir}/android-expo-override.json" "${SRC_PATH}/app/dist/build/${OTA_VERSION}/android-index.json"
     fi
 
     info "Copying OTA to CDN"
     aws --region "${AWS_REGION}" s3 sync --only-show-errors --delete "${SRC_PATH}/app/dist/build/${OTA_VERSION}" "s3://${OTA_ARTEFACT_BUCKET}/${OTA_ARTEFACT_PREFIX}/packages/${EXPO_APP_MAJOR_VERSION}/${OTA_VERSION}" || return $?
+    aws --region "${AWS_REGION}" s3 sync --only-show-errors --delete "${SRC_PATH}/app/dist/build/${OTA_VERSION}" "s3://${OTA_ARTEFACT_BUCKET}/${OTA_ARTEFACT_PREFIX}/archive/${BUILD_REFERENCE}" || return $?
 
     # Support using prebuild service or require that ejected directories exist
     if [[ ( "${BUILD_FORMATS[*]}" == *ios* && ! -d "${SRC_PATH}/${IOS_PROJECT_ROOT_DIR}" ) ||


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Adds the archive copy step for OTA's to ensure that source maps work for debugging with sentry

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Was removed during cleanup as it didn't have much evidence of use, but then found it straight away.. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

