### PR TITLE
fix: adjust sentry url prefix react-native apps

### DIFF
--- a/cli/runSentryRelease.sh
+++ b/cli/runSentryRelease.sh
@@ -200,12 +200,12 @@ function main() {
         find "${SOURCE_MAP_PATH}" -type f -name "main.jsbundle*" -exec cp {} "${react_source_maps}" \;
         find "${SOURCE_MAP_PATH}" -type f -name "index.android.bundle*" -exec cp {} "${react_source_maps}" \;
 
-        # enfore the react native requirements around paths and url prefix
+        # enforce the react native requirements around paths and url prefix
         SOURCE_MAP_PATH="${react_source_maps}"
 
-        if [[ "${SENTRY_URL_PREFIX}" != "~/" ]]; then
-            warn "Overrding the provided URL prefix ${SENTRY_URL_PREFIX} with ~/ to algin with react native requirements"
-            SENTRY_URL_PREFIX="~/"
+        if [[ "${SENTRY_URL_PREFIX}" != "app:///" ]]; then
+            warn "Overrding the provided URL prefix ${SENTRY_URL_PREFIX} with app:/// to align with react native requirements"
+            SENTRY_URL_PREFIX="app:///"
         fi
     ;;
 


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
The prefix for react-native sentry integration has been changed to "app:///"
## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Source maps are not working for recently reported errors, 
## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
locally
## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

