### PR TITLE
fix: add an empty suffix for running on MacOS

### DIFF
--- a/cli/runSentryRelease.sh
+++ b/cli/runSentryRelease.sh
@@ -183,7 +183,7 @@ function main() {
         if [[ -n "${android_bundle}" ]]; then
             mv "${android_bundle}" "${SOURCE_MAP_PATH}/index.android.bundle"
             android_map_basename="$(basename "${android_map}")"
-            sed -i "s/${android_map_basename}/index.android.bundle.map/g" "${SOURCE_MAP_PATH}/index.android.bundle"
+            sed -i '' "s/${android_map_basename}/index.android.bundle.map/g" "${SOURCE_MAP_PATH}/index.android.bundle"
         fi
 
         ios_map="$( find "${SOURCE_MAP_PATH}" -type f -name "ios-*.map" )"
@@ -195,7 +195,7 @@ function main() {
         if [[ -n "${ios_bundle}" ]]; then
             mv "${ios_bundle}" "${SOURCE_MAP_PATH}/main.jsbundle"
             ios_map_basename="$(basename "${ios_map}")"
-            sed -i "s/${ios_map_basename}/main.jsbundle.map/g" "${SOURCE_MAP_PATH}/main.jsbundle"
+            sed -i '' "s/${ios_map_basename}/main.jsbundle.map/g" "${SOURCE_MAP_PATH}/main.jsbundle"
         fi
 
         # move the files into a dedicated directory to ensure we upload them as the root


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
Fix the sed command syntax for correct sourceMappingURL replacement on MacOS
## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The correct value in sourceMappingURL is needed for the correct stacktrace frames to be shown in Sentry.
## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Locally
## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

