### PR TITLE
feat: add -d option for sentry distribution

### DIFF
--- a/cli/runSentryRelease.sh
+++ b/cli/runSentryRelease.sh
@@ -21,6 +21,7 @@ Usage: $(basename $0) -m SENTRY_SOURCE_MAP_S3_URL -r SENTRY_RELEASE -s -u DEPLOY
 where
 
 (o) -a APP_TYPE                     the app framework being used
+(o) -d DISTRIBUTION                 distribution for sentry release
 (m) -u DEPLOYMENT_UNIT              deployment unit for a build blueprint
 (o) -g DEPLOYMENT_GROUP             the deployment group the unit belongs to
     -h                              shows this text
@@ -50,6 +51,9 @@ function options() {
         case $opt in
             a)
                 APP_TYPE="${OPTARG}"
+                ;;
+            d)
+                DISTRIBUTION="${OPTARG}"
                 ;;
             g)
                 DEPLOYMENT_GROUP="${OPTARG}"
@@ -217,6 +221,10 @@ function main() {
 
   if [[ -n "${SENTRY_URL_PREFIX}" ]]; then
     upload_args+=("--url-prefix" "${SENTRY_URL_PREFIX}")
+  fi
+
+  if [[ -n "${DISTRIBUTION}" ]]; then
+    upload_args+=("--dist" "${DISTRIBUTION}")
   fi
 
   pushd "${SOURCE_MAP_PATH}" > /dev/null


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
Adds `-d` option to support --dist argument for sentry releases command
## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Sentry now requires distribution to be set along with the release during source maps upload for correct error processing.
## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Locally
## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

