### PR TITLE
refactor: ses password util and BASH_SOURCE

### DIFF
--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -26,7 +26,7 @@ export LOG_FORMAT_FULL="full"
 
 # -- Error tracing --
 # -- Output an errors source, line and function name --
-export PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+export PS4='+(${BASH_SOURCE[0]}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 declare -A LOG_LEVEL_ORDER
 LOG_LEVEL_ORDER=(
@@ -1207,14 +1207,6 @@ function create_iam_accesskey() {
     fatal "Could not generate accesskey for ${username}"
     return 255
   fi
-}
-
-function get_iam_smtp_password() {
-  local secretkey="$1"; shift
-
-  (echo -en "\x02"; echo -n 'SendRawEmail' \
-  | openssl dgst -sha256 -hmac $secretkey -binary) \
-  | openssl enc -base64
 }
 
 function manage_iam_userpassword() {


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
<!--- Describe your changes in detail -->
- Removes the ses password generation utility as is been removed from the AWS plugin
- Updates the BASH_SOURCE reference to align with it being an array

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The SES password attribute was removed in https://github.com/hamlet-io/engine-plugin-aws/pull/669 and is no longer supported by most AWS SES API endpoints 
BASH_SOURCE builtin env var is an array value rather than a string

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- https://github.com/hamlet-io/engine-plugin-aws/pull/669

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

