### PR TITLE
fix(setup): handle multiple remote ref matches

### DIFF
--- a/cli/setup.sh
+++ b/cli/setup.sh
@@ -127,7 +127,7 @@ function main() {
           # Git validation
           git_ref="$( git check-ref-format --allow-onelevel --normalize "${git_ref}" || fatal "Invalid ref ${git_ref}" >&2 ; return $? )"
           remote_ref="$( git ls-remote -q "${git_auth_url}" "${git_ref}" || fatal "Could not find remote plugin - id: ${plugin_instance_id} - Url: ${git_url} - Ref: ${git_ref}"; return $? )"
-          remote_hash="$( echo "${remote_ref}" | cut -f 1 )"
+          remote_hash="$( echo "${remote_ref}" | head -1 | cut -f 1 )"
 
           update_existing="false"
 


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
When querying whether a remote repo contains the desired reference, it is possible for more than one match to be returned. In this case, use the first match.

## Motivation and Context
- avoid errors being thrown 
- ensure the plugin state if fully populated

## How Has This Been Tested?
Local testing

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

