### PR TITLE
fix(expo): remove ITMSTRANSPORTER_FORCE_ITMS_PACKAGE_UPLOAD override

### DIFF
--- a/cli/runExpoAppPublish.sh
+++ b/cli/runExpoAppPublish.sh
@@ -782,8 +782,6 @@ function main() {
 
                         info "Submitting IOS binary to testflight"
                         export FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD="${IOS_TESTFLIGHT_PASSWORD}"
-                        # see https://github.com/fastlane/fastlane/issues/20756#issuecomment-1286277976
-                        export ITMSTRANSPORTER_FORCE_ITMS_PACKAGE_UPLOAD=true
                         # Handle removal of Transporter from xcode/Developer tools
                         if [[ -d "/Applications/Transporter.app/Contents/itms" ]]; then
                             export FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT=1


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
Using this now seems to raise a new error with the latest version of xcode 
https://github.com/fastlane/fastlane/issues/20756

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Publishing to iTunes Connect currently failing

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

