### PR TITLE
fix: set dir for git push

### DIFF
--- a/cli/saveCMDBRepos.sh
+++ b/cli/saveCMDBRepos.sh
@@ -180,7 +180,7 @@ function commit_tag_push() {
 
             debug "Pushing the repo upstream"
             if git -C "${repo_dir}" symbolic-ref -q HEAD; then
-                if git push --tags ${repo_remote} ${repo_branch}; then
+                if git -C "${repo_dir}" push --tags ${repo_remote} ${repo_branch}; then
                     REPO_PUSHED=true
                     break
                 else


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
Minor fix on cmdb save command which wasn't using -C for git push

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
the save cmdb command worked fine if you were in the repo dir but would break outside of it

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

