### PR TITLE
feat(db): add support for checking cluster username

### DIFF
--- a/execution/utility.sh
+++ b/execution/utility.sh
@@ -2476,15 +2476,19 @@ function get_rds_hostname() {
 
 function check_rds_snapshot_username() {
   local region="$1"; shift
+  local db_type="$1"; shift
   local db_snapshot_identifier="$1"; shift
   local expected_username="$1"; shift
 
   info "Checking snapshot username matches expected username"
 
-  snapshot_info="$(aws --region ${region} rds describe-db-snapshots --include-shared --include-public --db-snapshot-identifier ${db_snapshot_identifier} || return $? )"
+  if [[ "${db_type}" == "cluster" ]]; then
+    snapshot_username="$( aws --region ${region} rds describe-db-cluster-snapshots --include-shared --include-public --db-cluster-snapshot-identifier --output text --query 'DBClusterSnapshots[0].MasterUsername || ``' || return $? )"
+  else
+    snapshot_username="$(aws --region ${region} rds describe-db-snapshots --include-shared --include-public --db-snapshot-identifier ${db_snapshot_identifier} --output text --query 'DBSnapshots[0].MasterUsername || ``' || return $? )"
+  fi
 
   if [[ -n "${snapshot_info}" ]]; then
-    snapshot_username="$( echo "${snapshot_info}" | jq -r '.DBSnapshots[0].MasterUsername' )"
 
     if [[ "${snapshot_username}" != "${expected_username}" ]]; then
 


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
Adds support for checking a db cluster as well as a standard db instance when restoring from snapshots in RDS

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Deployment currently fails when restoring a cluster snapshot

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

